### PR TITLE
WIP: Loading external task options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,30 +4,31 @@ module.exports = function(grunt) {
 
   var path = require('path');
 
-  grunt.initConfig({
+  var config = {
 
     pkg: grunt.file.readJSON('package.json'),
+    env: process.env,
 
-    bower: {
-      install: {
-        options: {
-          targetDir: 'src/vendor/',
-          install: true,
-          verbose: true,
-          cleanBowerDir: true,
-          cleanTargetDir: true,
-          layout: function(type, component) {
-            if (type === 'img') {
-              return path.join('../../demo/static/img');
-            } else if (type === 'fonts') {
-              return path.join('../../demo/static/fonts');
-            } else {
-              return path.join(component);
-            }
-          }
-        }
-      }
-    },
+    // bower: {
+    //   install: {
+    //     options: {
+    //       targetDir: 'src/vendor/',
+    //       install: true,
+    //       verbose: true,
+    //       cleanBowerDir: true,
+    //       cleanTargetDir: true,
+    //       layout: function(type, component) {
+    //         if (type === 'img') {
+    //           return path.join('../../demo/static/img');
+    //         } else if (type === 'fonts') {
+    //           return path.join('../../demo/static/fonts');
+    //         } else {
+    //           return path.join(component);
+    //         }
+    //       }
+    //     }
+    //   }
+    // },
 
     clean: {
       vendor: [
@@ -190,7 +191,25 @@ module.exports = function(grunt) {
       }
     }
 
-  });
+  }; // closes var config
+
+  function loadConfig(path) {
+    var glob = require('glob');
+    var object = {};
+    var key;
+
+    glob.sync('*', {cwd: path}).forEach(function(option) {
+      key = option.replace(/\.js$/,'');
+      object[key] = require(path + option);
+      grunt.verbose.writeln("External config item - " + key + ": " + object[key]);
+    });
+
+    return object;
+  }
+
+  grunt.util._.extend(config, loadConfig('./node_modules/cf-grunt-config/tasks/options/'));
+
+  grunt.initConfig(config);
 
   /**
    * The above tasks are loaded here.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "cf-buttons",
   "version": "0.7.0",
   "description": "Button styles including default, secondary, destructive, disabled, super, and compound buttons, button links, buttons with icons, and button groups for Capital Framework.",
-  "keywords": ["capital-framework", "capital", "buttons", "less"],
+  "keywords": [
+    "capital-framework",
+    "capital",
+    "buttons",
+    "less"
+  ],
   "author": {
     "name": "Consumer Financial Protection Bureau",
     "url": "http://cfpb.github.io/"
@@ -24,6 +29,9 @@
     "node": ">=0.8.0"
   },
   "devDependencies": {
+    "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git",
+    "cf-grunt-config": "git://github.com/cfpb/cf-grunt-config.git",
+    "glob": "~3.2.9",
     "grunt": "latest",
     "grunt-autoprefixer": "latest",
     "grunt-bower-task": "~0.3.2",
@@ -32,7 +40,6 @@
     "grunt-contrib-copy": "latest",
     "grunt-contrib-less": "~0.8.3",
     "grunt-string-replace": "latest",
-    "grunt-topdoc": "~0.2.0",
-    "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git"
+    "grunt-topdoc": "~0.2.0"
   }
 }


### PR DESCRIPTION
@mikem and @contolini: Opening this PR to show you the proof of concept. I think we should wait to merge until we set up the rest of the common tasks, as well. I'll walk through it with you guys whenever it's convenient.
- Adds cf-grunt-config dependency to `package.json`
- Sets up `Gruntfile` to load task options from said cf-grunt-config
  package.

Dependent on cfpb/cf-grunt-config#2 to work correctly.
