### PR TITLE
Switch to jit-grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,7 +70,7 @@ module.exports = function(grunt) {
   /**
    * Load any project-specific tasks installed in the customary location.
    */
-  require('jit-grunt')(grunt);
+  require('load-grunt-tasks')(grunt);
 
 
   /**

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,26 @@ module.exports = function(grunt) {
 
   'use strict';
 
+  require('time-grunt')(grunt);
+
   var path = require('path');
+
+
+  /**
+   * Load the tasks we want to use, which are specified as dependencies in
+   * the package.json file of cf-grunt-config.
+   */
+
+  // Sets the CWD to the cf-grunt-config package so that the loadTasks method
+  // (employed in jit-grunt) looks in the correct place.
+  grunt.file.setBase('./node_modules/cf-grunt-config/');
+  // Loads all Grunt tasks in the node_modules directory within the new CWD.
+  require('jit-grunt')(grunt, {
+    // Below line needed because task name does not match package name
+    bower: 'grunt-bower-task'
+  });
+  // Sets the CWD back to the project root so that the tasks work as expected.
+  grunt.file.setBase('../../');
 
 
   /**
@@ -49,19 +68,9 @@ module.exports = function(grunt) {
 
 
   /**
-   * Load the tasks we want to use, which are specified as dependencies in
-   * the package.json file of cf-grunt-config.
+   * Load any project-specific tasks installed in the customary location.
    */
-
-  // Sets the CWD to the cf-grunt-config package so that the loadNpmTasks method
-  // (employed in load-grunt-tasks) looks in the correct place.
-  grunt.file.setBase('./node_modules/cf-grunt-config/');
-  // Loads all Grunt tasks in the node_modules directory within the new CWD.
-  require('load-grunt-tasks')(grunt);
-  // Sets the CWD back to the project root so that the tasks work as expected.
-  grunt.file.setBase('../../');
-  // Load any project-specific tasks installed in the customary location.
-  require('load-grunt-tasks')(grunt);
+  require('jit-grunt')(grunt);
 
 
   /**

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cf-grunt-config": "git://github.com/cfpb/cf-grunt-config.git",
     "glob": "~3.2.9",
     "grunt": "latest",
-    "load-grunt-tasks": "latest"
+    "jit-grunt": "latest",
+    "time-grunt": "latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "glob": "~3.2.9",
     "grunt": "latest",
     "jit-grunt": "latest",
+    "load-grunt-tasks": "latest",
     "time-grunt": "latest"
   }
 }


### PR DESCRIPTION
See https://github.com/shootaroo/jit-grunt
- Enables on-demand task loading, instead of loading all tasks every
  time Grunt is invoked.
- Fixes bug when running bower:install via load-grunt-tasks
- Also installed time-grunt for performance measurement
