### PR TITLE
Add pa11y automated accessibility test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - 0.10
+  - 0.12

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # cf-buttons
 
+[![Build Status](https://img.shields.io/travis/cfpb/cf-buttons.svg)](https://travis-ci.org/cfpb/cf-buttons) 
 [![npm dependency status](https://gemnasium.com/cfpb/cf-buttons.svg)](https://gemnasium.com/cfpb/cf-buttons)
 
 Button styles including default, secondary, destructive, disabled, super, and
@@ -35,6 +36,14 @@ We welcome your feedback and contributions.
 - [Find out about contributing](CONTRIBUTING.md)
 - File a bug using this [handy template](https://github.com/cfpb/cf-buttons/issues/new?body=%23%23%20URL%0D%0D%0D%23%23%20Actual%20Behavior%0D%0D%0D%23%23%20Expected%20Behavior%0D%0D%0D%23%23%20Steps%20to%20Reproduce%0D%0D%0D%23%23%20Screenshot&labels=bug)
 
+## Running tests
+
+Before contributing to our codebase, please ensure all tests pass. After cloning this repository to your machine, run:
+
+```sh
+$ npm install
+$ npm test
+```
 
 ----
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,29 +27,29 @@
     <div id="default-button">
       <div>
         <div>
-<a href="#" class="btn">Anchor Tag</a>
-<button class="btn">Button Tag</button>
+<a href="#" class="btn" title="Test button">Anchor Tag</a>
+<button class="btn" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn">
 </div><br>
       </div>
       <div>
         <div>
-<a href="#" class="btn hover">Anchor Tag</a>
-<button class="btn hover">Button Tag</button>
+<a href="#" class="btn hover" title="Test button">Anchor Tag</a>
+<button class="btn hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn hover">
 </div><br>
       </div>
       <div>
         <div>
-<a href="#" class="btn focus">Anchor Tag</a>
-<button class="btn focus">Button Tag</button>
+<a href="#" class="btn focus" title="Test button">Anchor Tag</a>
+<button class="btn focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn focus">
 </div><br>
       </div>
       <div>
         <div>
-<a href="#" class="btn active">Anchor Tag</a>
-<button class="btn active">Button Tag</button>
+<a href="#" class="btn active" title="Test button">Anchor Tag</a>
+<button class="btn active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn active">
 </div><br>
       </div>
@@ -58,28 +58,28 @@
       <div>
         <div>
 <a href="#" class="btn btn__secondary">Anchor Tag</a>
-<button class="btn btn__secondary">Button Tag</button>
+<button class="btn btn__secondary" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__secondary hover">Anchor Tag</a>
-<button class="btn btn__secondary hover">Button Tag</button>
+<button class="btn btn__secondary hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary hover">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__secondary focus">Anchor Tag</a>
-<button class="btn btn__secondary focus">Button Tag</button>
+<button class="btn btn__secondary focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary focus">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__secondary active">Anchor Tag</a>
-<button class="btn btn__secondary active">Button Tag</button>
+<button class="btn btn__secondary active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary active">
 </div><br>
       </div>
@@ -88,28 +88,28 @@
       <div>
         <div>
 <a href="#" class="btn btn__warning">Anchor Tag</a>
-<button class="btn btn__warning">Button Tag</button>
+<button class="btn btn__warning" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__warning hover">Anchor Tag</a>
-<button class="btn btn__warning hover">Button Tag</button>
+<button class="btn btn__warning hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning hover">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__warning focus">Anchor Tag</a>
-<button class="btn btn__warning focus">Button Tag</button>
+<button class="btn btn__warning focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning focus">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__warning active">Anchor Tag</a>
-<button class="btn btn__warning active">Button Tag</button>
+<button class="btn btn__warning active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning active">
 </div><br>
       </div>
@@ -118,17 +118,17 @@
       <div>
         <div>
 <a href="#" class="btn btn__disabled">Anchor Tag</a>
-<button class="btn btn__disabled">Button Tag</button>
+<button class="btn btn__disabled" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__disabled">
-<button class="btn" disabled>Button Tag w/ disabled attr</button>
+<button class="btn" disabled title="Test button">Button Tag w/ disabled attr</button>
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__disabled focus">Anchor Tag</a>
-<button class="btn btn__disabled focus">Button Tag</button>
+<button class="btn btn__disabled focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__disabled focus">
-<button class="btn focus" disabled>Button Tag w/ disabled attr</button>
+<button class="btn focus" disabled title="Test button">Button Tag w/ disabled attr</button>
 </div><br>
       </div>
     </div>
@@ -136,28 +136,28 @@
       <div>
         <div>
 <a href="#" class="btn btn__super">Anchor Tag</a>
-<button class="btn btn__super">Button Tag</button>
+<button class="btn btn__super" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__super hover">Anchor Tag</a>
-<button class="btn btn__super hover">Button Tag</button>
+<button class="btn btn__super hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super hover">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__super focus">Anchor Tag</a>
-<button class="btn btn__super focus">Button Tag</button>
+<button class="btn btn__super focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super focus">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__super active">Anchor Tag</a>
-<button class="btn btn__super active">Button Tag</button>
+<button class="btn btn__super active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super active">
 </div><br>
       </div>
@@ -169,7 +169,7 @@
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Anchor Tag
 </a>
-<button class="btn">
+<button class="btn" title="Test button">
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Button Tag
 </button>
@@ -179,7 +179,7 @@
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Anchor Tag
 </a>
-<button class="btn btn__secondary">
+<button class="btn btn__secondary" title="Test button">
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Button Tag
 </button>
@@ -189,7 +189,7 @@
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Anchor Tag
 </a>
-<button class="btn btn__warning">
+<button class="btn btn__warning" title="Test button">
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Button Tag
 </button>
@@ -199,11 +199,11 @@
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Anchor Tag
 </a>
-<button class="btn btn__disabled">
+<button class="btn btn__disabled" title="Test button">
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Button Tag
 </button>
-<button class="btn" disabled>
+<button class="btn" disabled title="Test button">
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Button Tag w/ disabled attr
 </button>
@@ -215,7 +215,7 @@
     Anchor Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </a>
-<button class="btn">
+<button class="btn" title="Test button">
     Button Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </button>
@@ -225,7 +225,7 @@
     Anchor Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </a>
-<button class="btn btn__secondary">
+<button class="btn btn__secondary" title="Test button">
     Button Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </button>
@@ -235,7 +235,7 @@
     Anchor Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </a>
-<button class="btn btn__warning">
+<button class="btn btn__warning" title="Test button">
     Button Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </button>
@@ -245,11 +245,11 @@
     Anchor Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </a>
-<button class="btn btn__disabled">
+<button class="btn btn__disabled" title="Test button">
     Button Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </button>
-<button class="btn" disabled>
+<button class="btn" disabled title="Test button">
     Button Tag w/ disabled attr
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </button>
@@ -261,7 +261,7 @@
     <span class="u-visually-hidden">Search</span>
     <span class="cf-icon cf-icon-search"></span>
 </a>
-<button class="btn">
+<button class="btn" title="Test button">
     <span class="u-visually-hidden">Search</span>
     <span class="cf-icon cf-icon-search"></span>
 </button>
@@ -276,9 +276,9 @@
 <a href="#" class="btn btn__grouped-last">Anchor 3</a>
 <br>
 <br>
-<button class="btn btn__grouped-first">Button 1</button>
-<button class="btn btn__grouped">Button 2</button>
-<button class="btn btn__grouped-last">Button 3</button>
+<button class="btn btn__grouped-first" title="Test button">Button 1</button>
+<button class="btn btn__grouped" title="Test button">Button 2</button>
+<button class="btn btn__grouped-last" title="Test button">Button 3</button>
 <br>
 <br>
 <input type="button" value="Input 1" class="btn btn__grouped-first">
@@ -293,9 +293,9 @@
 <a href="#" class="btn btn__grouped-last btn__super">Anchor 3</a>
 <br>
 <br>
-<button class="btn btn__grouped-first btn__super">Button 1</button>
-<button class="btn btn__grouped btn__super">Button 2</button>
-<button class="btn btn__grouped-last btn__super">Button 3</button>
+<button class="btn btn__grouped-first btn__super" title="Test button">Button 1</button>
+<button class="btn btn__grouped btn__super" title="Test button">Button 2</button>
+<button class="btn btn__grouped-last btn__super" title="Test button">Button 3</button>
 <br>
 <br>
 <input type="button" value="Input 1" class="btn btn__grouped-first btn__super">
@@ -313,8 +313,8 @@
 </a>
 <br>
 <br>
-<button class="btn btn__grouped-first">Button</button>
-<button class="btn btn__grouped-last btn__compound-action">
+<button class="btn btn__grouped-first" title="Test button">Button</button>
+<button class="btn btn__grouped-last btn__compound-action" title="Test button">
     <span class="cf-icon cf-icon-down btn__grouped-last"></span>
 </button>
 <br>
@@ -325,8 +325,8 @@
 </a>
 <br>
 <br>
-<button class="btn btn__grouped-first btn__secondary">Button</button>
-<button class="btn btn__grouped-last btn__secondary btn__compound-action">
+<button class="btn btn__grouped-first btn__secondary" title="Test button">Button</button>
+<button class="btn btn__grouped-last btn__secondary btn__compound-action" title="Test button">
     <span class="cf-icon cf-icon-down btn__grouped-last"></span>
 </button>
 <br>
@@ -337,8 +337,8 @@
 </a>
 <br>
 <br>
-<button class="btn btn__grouped-first btn__warning">Button</button>
-<button class="btn btn__grouped-last btn__warning btn__compound-action">
+<button class="btn btn__grouped-first btn__warning" title="Test button">Button</button>
+<button class="btn btn__grouped-last btn__warning btn__compound-action" title="Test button">
     <span class="cf-icon cf-icon-down btn__grouped-last"></span>
 </button>
 <br>
@@ -349,14 +349,14 @@
 </a>
 <br>
 <br>
-<button class="btn btn__grouped-first btn__disabled">Button</button>
-<button class="btn btn__grouped-last btn__disabled btn__compound-action">
+<button class="btn btn__grouped-first btn__disabled" title="Test button">Button</button>
+<button class="btn btn__grouped-last btn__disabled btn__compound-action" title="Test button">
     <span class="cf-icon cf-icon-down btn__grouped-last"></span>
 </button>
 <br>
 <br>
-<button class="btn btn__grouped-first" disabled>Button w/ disabled attr</button>
-<button class="btn btn__grouped-last btn__compound-action" disabled>
+<button class="btn btn__grouped-first" disabled title="Test button">Button w/ disabled attr</button>
+<button class="btn btn__grouped-last btn__compound-action" disabled title="Test button">
     <span class="cf-icon cf-icon-down btn__grouped-last"></span>
 </button>
 <br>
@@ -367,8 +367,8 @@
 </a>
 <br>
 <br>
-<button class="btn btn__grouped-first btn__super">Button</button>
-<button class="btn btn__grouped-last btn__super btn__compound-action">
+<button class="btn btn__grouped-first btn__super" title="Test button">Button</button>
+<button class="btn btn__grouped-last btn__super btn__compound-action" title="Test button">
     <span class="cf-icon cf-icon-down btn__grouped-last"></span>
 </button>
 </div><br>
@@ -378,28 +378,28 @@
       <div>
         <div>
 <a href="#" class="btn btn__link">Anchor Tag</a>
-<button class="btn btn__link">Button Tag</button>
+<button class="btn btn__link" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__link hover">Anchor Tag</a>
-<button class="btn btn__link hover">Button Tag</button>
+<button class="btn btn__link hover" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link hover">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__link focus">Anchor Tag</a>
-<button class="btn btn__link focus">Button Tag</button>
+<button class="btn btn__link focus" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link focus">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__link active">Anchor Tag</a>
-<button class="btn btn__link active">Button Tag</button>
+<button class="btn btn__link active" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link active">
 </div><br>
       </div>
@@ -408,28 +408,28 @@
       <div>
         <div>
 <a href="#" class="btn btn__link btn__secondary">Anchor Tag</a>
-<button class="btn btn__link btn__secondary">Button Tag</button>
+<button class="btn btn__link btn__secondary" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__secondary">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__link btn__secondary hover">Anchor Tag</a>
-<button class="btn btn__link btn__secondary hover">Button Tag</button>
+<button class="btn btn__link btn__secondary hover" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__secondary hover">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__link btn__secondary focus">Anchor Tag</a>
-<button class="btn btn__link btn__secondary focus">Button Tag</button>
+<button class="btn btn__link btn__secondary focus" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__secondary focus">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__link btn__secondary active">Anchor Tag</a>
-<button class="btn btn__link btn__secondary active">Button Tag</button>
+<button class="btn btn__link btn__secondary active" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__secondary active">
 </div><br>
       </div>
@@ -438,28 +438,28 @@
       <div>
         <div>
 <a href="#" class="btn btn__link btn__warning">Anchor Tag</a>
-<button class="btn btn__link btn__warning">Button Tag</button>
+<button class="btn btn__link btn__warning" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__warning">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__link btn__warning hover">Anchor Tag</a>
-<button class="btn btn__link btn__warning hover">Button Tag</button>
+<button class="btn btn__link btn__warning hover" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__warning hover">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__link btn__warning focus">Anchor Tag</a>
-<button class="btn btn__link btn__warning focus">Button Tag</button>
+<button class="btn btn__link btn__warning focus" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__warning focus">
 </div><br>
       </div>
       <div>
         <div>
 <a href="#" class="btn btn__link btn__warning active">Anchor Tag</a>
-<button class="btn btn__link btn__warning active">Button Tag</button>
+<button class="btn btn__link btn__warning active" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__warning active">
 </div><br>
       </div>

--- a/demo/static/css/main.css
+++ b/demo/static/css/main.css
@@ -53,23 +53,23 @@
   patterns:
   - name: Default state
     markup: |
-      <a href="#" class="btn">Anchor Tag</a>
-      <button class="btn">Button Tag</button>
+      <a href="#" class="btn" title="Test button">Anchor Tag</a>
+      <button class="btn" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn">
   - name: Hovered state
     markup: |
-      <a href="#" class="btn hover">Anchor Tag</a>
-      <button class="btn hover">Button Tag</button>
+      <a href="#" class="btn hover" title="Test button">Anchor Tag</a>
+      <button class="btn hover" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn hover">
   - name: Focused state
     markup: |
-      <a href="#" class="btn focus">Anchor Tag</a>
-      <button class="btn focus">Button Tag</button>
+      <a href="#" class="btn focus" title="Test button">Anchor Tag</a>
+      <button class="btn focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn focus">
   - name: Active state
     markup: |
-      <a href="#" class="btn active">Anchor Tag</a>
-      <button class="btn active">Button Tag</button>
+      <a href="#" class="btn active" title="Test button">Anchor Tag</a>
+      <button class="btn active" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn active">
   tags:
   - cf-buttons
@@ -144,22 +144,22 @@ input.btn::-moz-focus-inner {
   - name: Default state
     markup: |
       <a href="#" class="btn btn__secondary">Anchor Tag</a>
-      <button class="btn btn__secondary">Button Tag</button>
+      <button class="btn btn__secondary" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__secondary">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__secondary hover">Anchor Tag</a>
-      <button class="btn btn__secondary hover">Button Tag</button>
+      <button class="btn btn__secondary hover" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__secondary hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__secondary focus">Anchor Tag</a>
-      <button class="btn btn__secondary focus">Button Tag</button>
+      <button class="btn btn__secondary focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__secondary focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__secondary active">Anchor Tag</a>
-      <button class="btn btn__secondary active">Button Tag</button>
+      <button class="btn btn__secondary active" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__secondary active">
   tags:
   - cf-buttons
@@ -193,22 +193,22 @@ input.btn::-moz-focus-inner {
   - name: Default state
     markup: |
       <a href="#" class="btn btn__warning">Anchor Tag</a>
-      <button class="btn btn__warning">Button Tag</button>
+      <button class="btn btn__warning" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__warning">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__warning hover">Anchor Tag</a>
-      <button class="btn btn__warning hover">Button Tag</button>
+      <button class="btn btn__warning hover" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__warning hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__warning focus">Anchor Tag</a>
-      <button class="btn btn__warning focus">Button Tag</button>
+      <button class="btn btn__warning focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__warning focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__warning active">Anchor Tag</a>
-      <button class="btn btn__warning active">Button Tag</button>
+      <button class="btn btn__warning active" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__warning active">
   tags:
   - cf-buttons
@@ -244,15 +244,15 @@ input.btn::-moz-focus-inner {
   - name: Default/hovered/active state
     markup: |
       <a href="#" class="btn btn__disabled">Anchor Tag</a>
-      <button class="btn btn__disabled">Button Tag</button>
+      <button class="btn btn__disabled" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__disabled">
-      <button class="btn" disabled>Button Tag w/ disabled attr</button>
+      <button class="btn" disabled title="Test button">Button Tag w/ disabled attr</button>
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__disabled focus">Anchor Tag</a>
-      <button class="btn btn__disabled focus">Button Tag</button>
+      <button class="btn btn__disabled focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__disabled focus">
-      <button class="btn focus" disabled>Button Tag w/ disabled attr</button>
+      <button class="btn focus" disabled title="Test button">Button Tag w/ disabled attr</button>
   tags:
   - cf-buttons
 */
@@ -292,22 +292,22 @@ input.btn::-moz-focus-inner {
   - name: Default state
     markup: |
       <a href="#" class="btn btn__super">Anchor Tag</a>
-      <button class="btn btn__super">Button Tag</button>
+      <button class="btn btn__super" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__super">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__super hover">Anchor Tag</a>
-      <button class="btn btn__super hover">Button Tag</button>
+      <button class="btn btn__super hover" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__super hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__super focus">Anchor Tag</a>
-      <button class="btn btn__super focus">Button Tag</button>
+      <button class="btn btn__super focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__super focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__super active">Anchor Tag</a>
-      <button class="btn btn__super active">Button Tag</button>
+      <button class="btn btn__super active" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__super active">
   tags:
   - cf-buttons
@@ -334,7 +334,7 @@ input.btn::-moz-focus-inner {
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Anchor Tag
       </a>
-      <button class="btn">
+      <button class="btn" title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag
       </button>
@@ -344,7 +344,7 @@ input.btn::-moz-focus-inner {
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Anchor Tag
       </a>
-      <button class="btn btn__secondary">
+      <button class="btn btn__secondary" title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag
       </button>
@@ -354,7 +354,7 @@ input.btn::-moz-focus-inner {
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Anchor Tag
       </a>
-      <button class="btn btn__warning">
+      <button class="btn btn__warning" title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag
       </button>
@@ -364,11 +364,11 @@ input.btn::-moz-focus-inner {
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Anchor Tag
       </a>
-      <button class="btn btn__disabled">
+      <button class="btn btn__disabled" title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag
       </button>
-      <button class="btn" disabled>
+      <button class="btn" disabled title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag w/ disabled attr
       </button>
@@ -378,7 +378,7 @@ input.btn::-moz-focus-inner {
           Anchor Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </a>
-      <button class="btn">
+      <button class="btn" title="Test button">
           Button Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
@@ -388,7 +388,7 @@ input.btn::-moz-focus-inner {
           Anchor Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </a>
-      <button class="btn btn__secondary">
+      <button class="btn btn__secondary" title="Test button">
           Button Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
@@ -398,7 +398,7 @@ input.btn::-moz-focus-inner {
           Anchor Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </a>
-      <button class="btn btn__warning">
+      <button class="btn btn__warning" title="Test button">
           Button Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
@@ -408,11 +408,11 @@ input.btn::-moz-focus-inner {
           Anchor Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </a>
-      <button class="btn btn__disabled">
+      <button class="btn btn__disabled" title="Test button">
           Button Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
-      <button class="btn" disabled>
+      <button class="btn" disabled title="Test button">
           Button Tag w/ disabled attr
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
@@ -422,7 +422,7 @@ input.btn::-moz-focus-inner {
           <span class="u-visually-hidden">Search</span>
           <span class="cf-icon cf-icon-search"></span>
       </a>
-      <button class="btn">
+      <button class="btn" title="Test button">
           <span class="u-visually-hidden">Search</span>
           <span class="cf-icon cf-icon-search"></span>
       </button>
@@ -483,9 +483,9 @@ input.btn::-moz-focus-inner {
       <a href="#" class="btn btn__grouped-last">Anchor 3</a>
       <br>
       <br>
-      <button class="btn btn__grouped-first">Button 1</button>
-      <button class="btn btn__grouped">Button 2</button>
-      <button class="btn btn__grouped-last">Button 3</button>
+      <button class="btn btn__grouped-first" title="Test button">Button 1</button>
+      <button class="btn btn__grouped" title="Test button">Button 2</button>
+      <button class="btn btn__grouped-last" title="Test button">Button 3</button>
       <br>
       <br>
       <input type="button" value="Input 1" class="btn btn__grouped-first">
@@ -498,9 +498,9 @@ input.btn::-moz-focus-inner {
       <a href="#" class="btn btn__grouped-last btn__super">Anchor 3</a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__super">Button 1</button>
-      <button class="btn btn__grouped btn__super">Button 2</button>
-      <button class="btn btn__grouped-last btn__super">Button 3</button>
+      <button class="btn btn__grouped-first btn__super" title="Test button">Button 1</button>
+      <button class="btn btn__grouped btn__super" title="Test button">Button 2</button>
+      <button class="btn btn__grouped-last btn__super" title="Test button">Button 3</button>
       <br>
       <br>
       <input type="button" value="Input 1" class="btn btn__grouped-first btn__super">
@@ -553,8 +553,8 @@ input.btn::-moz-focus-inner {
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first">Button</button>
-      <button class="btn btn__grouped-last btn__compound-action">
+      <button class="btn btn__grouped-first" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
@@ -565,8 +565,8 @@ input.btn::-moz-focus-inner {
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__secondary">Button</button>
-      <button class="btn btn__grouped-last btn__secondary btn__compound-action">
+      <button class="btn btn__grouped-first btn__secondary" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__secondary btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
@@ -577,8 +577,8 @@ input.btn::-moz-focus-inner {
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__warning">Button</button>
-      <button class="btn btn__grouped-last btn__warning btn__compound-action">
+      <button class="btn btn__grouped-first btn__warning" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__warning btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
@@ -589,14 +589,14 @@ input.btn::-moz-focus-inner {
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__disabled">Button</button>
-      <button class="btn btn__grouped-last btn__disabled btn__compound-action">
+      <button class="btn btn__grouped-first btn__disabled" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__disabled btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
       <br>
-      <button class="btn btn__grouped-first" disabled>Button w/ disabled attr</button>
-      <button class="btn btn__grouped-last btn__compound-action" disabled>
+      <button class="btn btn__grouped-first" disabled title="Test button">Button w/ disabled attr</button>
+      <button class="btn btn__grouped-last btn__compound-action" disabled title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
@@ -607,8 +607,8 @@ input.btn::-moz-focus-inner {
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__super">Button</button>
-      <button class="btn btn__grouped-last btn__super btn__compound-action">
+      <button class="btn btn__grouped-first btn__super" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__super btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
   tags:
@@ -665,22 +665,22 @@ input.btn::-moz-focus-inner {
   - name: Default state
     markup: |
       <a href="#" class="btn btn__link">Anchor Tag</a>
-      <button class="btn btn__link">Button Tag</button>
+      <button class="btn btn__link" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__link hover">Anchor Tag</a>
-      <button class="btn btn__link hover">Button Tag</button>
+      <button class="btn btn__link hover" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__link focus">Anchor Tag</a>
-      <button class="btn btn__link focus">Button Tag</button>
+      <button class="btn btn__link focus" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__link active">Anchor Tag</a>
-      <button class="btn btn__link active">Button Tag</button>
+      <button class="btn btn__link active" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link active">
   tags:
   - cf-buttons
@@ -730,22 +730,22 @@ input.btn::-moz-focus-inner {
   - name: Default state
     markup: |
       <a href="#" class="btn btn__link btn__secondary">Anchor Tag</a>
-      <button class="btn btn__link btn__secondary">Button Tag</button>
+      <button class="btn btn__link btn__secondary" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__secondary">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__link btn__secondary hover">Anchor Tag</a>
-      <button class="btn btn__link btn__secondary hover">Button Tag</button>
+      <button class="btn btn__link btn__secondary hover" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__secondary hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__link btn__secondary focus">Anchor Tag</a>
-      <button class="btn btn__link btn__secondary focus">Button Tag</button>
+      <button class="btn btn__link btn__secondary focus" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__secondary focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__link btn__secondary active">Anchor Tag</a>
-      <button class="btn btn__link btn__secondary active">Button Tag</button>
+      <button class="btn btn__link btn__secondary active" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__secondary active">
   tags:
   - cf-buttons
@@ -781,22 +781,22 @@ input.btn::-moz-focus-inner {
   - name: Default state
     markup: |
       <a href="#" class="btn btn__link btn__warning">Anchor Tag</a>
-      <button class="btn btn__link btn__warning">Button Tag</button>
+      <button class="btn btn__link btn__warning" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__warning">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__link btn__warning hover">Anchor Tag</a>
-      <button class="btn btn__link btn__warning hover">Button Tag</button>
+      <button class="btn btn__link btn__warning hover" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__warning hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__link btn__warning focus">Anchor Tag</a>
-      <button class="btn btn__link btn__warning focus">Button Tag</button>
+      <button class="btn btn__link btn__warning focus" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__warning focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__link btn__warning active">Anchor Tag</a>
-      <button class="btn btn__link btn__warning active">Button Tag</button>
+      <button class="btn btn__link btn__warning active" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__warning active">
   tags:
   - cf-buttons

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,17 +84,17 @@
             <div class="docs-pattern">
               <h3 class="docs-pattern_header">Default state</h3>
               <section class="docs-pattern_pattern">
-<a href="#" class="btn">Anchor Tag</a>
-<button class="btn">Button Tag</button>
+<a href="#" class="btn" title="Test button">Anchor Tag</a>
+<button class="btn" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn">
 
               </section>
               <footer class="docs-pattern_footer">
-                <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn&quot;&gt;Button Tag&lt;/button&gt;
+                <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn&quot; title=&quot;Test button&quot;&gt;Anchor Tag&lt;/a&gt;
+&lt;button class=&quot;btn&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -102,17 +102,17 @@
             <div class="docs-pattern">
               <h3 class="docs-pattern_header">Hovered state</h3>
               <section class="docs-pattern_pattern">
-<a href="#" class="btn hover">Anchor Tag</a>
-<button class="btn hover">Button Tag</button>
+<a href="#" class="btn hover" title="Test button">Anchor Tag</a>
+<button class="btn hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn hover">
 
               </section>
               <footer class="docs-pattern_footer">
-                <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn hover&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn hover&quot;&gt;Button Tag&lt;/button&gt;
+                <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn hover&quot; title=&quot;Test button&quot;&gt;Anchor Tag&lt;/a&gt;
+&lt;button class=&quot;btn hover&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn hover&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn hover\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn hover\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn hover\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn hover\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn hover\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn hover\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -120,17 +120,17 @@
             <div class="docs-pattern">
               <h3 class="docs-pattern_header">Focused state</h3>
               <section class="docs-pattern_pattern">
-<a href="#" class="btn focus">Anchor Tag</a>
-<button class="btn focus">Button Tag</button>
+<a href="#" class="btn focus" title="Test button">Anchor Tag</a>
+<button class="btn focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn focus">
 
               </section>
               <footer class="docs-pattern_footer">
-                <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn focus&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn focus&quot;&gt;Button Tag&lt;/button&gt;
+                <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn focus&quot; title=&quot;Test button&quot;&gt;Anchor Tag&lt;/a&gt;
+&lt;button class=&quot;btn focus&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn focus&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn focus\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn focus\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn focus\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn focus\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn focus\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -138,17 +138,17 @@
             <div class="docs-pattern">
               <h3 class="docs-pattern_header">Active state</h3>
               <section class="docs-pattern_pattern">
-<a href="#" class="btn active">Anchor Tag</a>
-<button class="btn active">Button Tag</button>
+<a href="#" class="btn active" title="Test button">Anchor Tag</a>
+<button class="btn active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn active">
 
               </section>
               <footer class="docs-pattern_footer">
-                <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn active&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn active&quot;&gt;Button Tag&lt;/button&gt;
+                <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn active&quot; title=&quot;Test button&quot;&gt;Anchor Tag&lt;/a&gt;
+&lt;button class=&quot;btn active&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn active&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn active\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn active\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn active\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn active\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn active\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn active\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -229,16 +229,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Default state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__secondary">Anchor Tag</a>
-<button class="btn btn__secondary">Button Tag</button>
+<button class="btn btn__secondary" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__secondary&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__secondary&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__secondary&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__secondary&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__secondary\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__secondary\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__secondary\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__secondary\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__secondary\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__secondary\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -247,16 +247,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Hovered state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__secondary hover">Anchor Tag</a>
-<button class="btn btn__secondary hover">Button Tag</button>
+<button class="btn btn__secondary hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary hover">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__secondary hover&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__secondary hover&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__secondary hover&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__secondary hover&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__secondary hover\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__secondary hover\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__secondary hover\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__secondary hover\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__secondary hover\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__secondary hover\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -265,16 +265,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Focused state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__secondary focus">Anchor Tag</a>
-<button class="btn btn__secondary focus">Button Tag</button>
+<button class="btn btn__secondary focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary focus">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__secondary focus&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__secondary focus&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__secondary focus&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__secondary focus&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__secondary focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__secondary focus\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__secondary focus\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__secondary focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__secondary focus\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__secondary focus\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -283,16 +283,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Active state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__secondary active">Anchor Tag</a>
-<button class="btn btn__secondary active">Button Tag</button>
+<button class="btn btn__secondary active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary active">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__secondary active&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__secondary active&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__secondary active&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__secondary active&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__secondary active\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__secondary active\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__secondary active\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__secondary active\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__secondary active\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__secondary active\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -332,16 +332,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Default state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__warning">Anchor Tag</a>
-<button class="btn btn__warning">Button Tag</button>
+<button class="btn btn__warning" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__warning&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__warning&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__warning&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__warning&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__warning\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__warning\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__warning\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__warning\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__warning\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__warning\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -350,16 +350,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Hovered state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__warning hover">Anchor Tag</a>
-<button class="btn btn__warning hover">Button Tag</button>
+<button class="btn btn__warning hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning hover">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__warning hover&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__warning hover&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__warning hover&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__warning hover&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__warning hover\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__warning hover\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__warning hover\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__warning hover\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__warning hover\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__warning hover\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -368,16 +368,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Focused state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__warning focus">Anchor Tag</a>
-<button class="btn btn__warning focus">Button Tag</button>
+<button class="btn btn__warning focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning focus">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__warning focus&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__warning focus&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__warning focus&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__warning focus&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__warning focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__warning focus\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__warning focus\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__warning focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__warning focus\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__warning focus\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -386,16 +386,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Active state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__warning active">Anchor Tag</a>
-<button class="btn btn__warning active">Button Tag</button>
+<button class="btn btn__warning active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning active">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__warning active&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__warning active&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__warning active&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__warning active&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__warning active\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__warning active\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__warning active\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__warning active\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__warning active\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__warning active\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -436,18 +436,18 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Default/hovered/active state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__disabled">Anchor Tag</a>
-<button class="btn btn__disabled">Button Tag</button>
+<button class="btn btn__disabled" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__disabled">
-<button class="btn" disabled>Button Tag w/ disabled attr</button>
+<button class="btn" disabled title="Test button">Button Tag w/ disabled attr</button>
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__disabled&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__disabled&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__disabled&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__disabled&quot;&gt;
-&lt;button class=&quot;btn&quot; disabled&gt;Button Tag w/ disabled attr&lt;/button&gt;</code></pre>
+&lt;button class=&quot;btn&quot; disabled title=&quot;Test button&quot;&gt;Button Tag w/ disabled attr&lt;/button&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__disabled\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__disabled\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__disabled\&amp;quot;&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot; disabled&gt;Button Tag w/ disabled attr&lt;/button&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__disabled\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__disabled\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__disabled\&amp;quot;&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot; disabled title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag w/ disabled attr&lt;/button&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -456,18 +456,18 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Focused state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__disabled focus">Anchor Tag</a>
-<button class="btn btn__disabled focus">Button Tag</button>
+<button class="btn btn__disabled focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__disabled focus">
-<button class="btn focus" disabled>Button Tag w/ disabled attr</button>
+<button class="btn focus" disabled title="Test button">Button Tag w/ disabled attr</button>
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__disabled focus&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__disabled focus&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__disabled focus&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__disabled focus&quot;&gt;
-&lt;button class=&quot;btn focus&quot; disabled&gt;Button Tag w/ disabled attr&lt;/button&gt;</code></pre>
+&lt;button class=&quot;btn focus&quot; disabled title=&quot;Test button&quot;&gt;Button Tag w/ disabled attr&lt;/button&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__disabled focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__disabled focus\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__disabled focus\&amp;quot;&gt;\n&lt;button class=\&amp;quot;btn focus\&amp;quot; disabled&gt;Button Tag w/ disabled attr&lt;/button&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__disabled focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__disabled focus\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__disabled focus\&amp;quot;&gt;\n&lt;button class=\&amp;quot;btn focus\&amp;quot; disabled title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag w/ disabled attr&lt;/button&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -512,16 +512,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Default state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__super">Anchor Tag</a>
-<button class="btn btn__super">Button Tag</button>
+<button class="btn btn__super" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__super&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__super&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__super&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__super&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__super\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__super\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__super\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__super\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__super\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__super\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -530,16 +530,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Hovered state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__super hover">Anchor Tag</a>
-<button class="btn btn__super hover">Button Tag</button>
+<button class="btn btn__super hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super hover">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__super hover&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__super hover&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__super hover&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__super hover&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__super hover\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__super hover\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__super hover\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__super hover\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__super hover\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__super hover\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -548,16 +548,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Focused state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__super focus">Anchor Tag</a>
-<button class="btn btn__super focus">Button Tag</button>
+<button class="btn btn__super focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super focus">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__super focus&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__super focus&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__super focus&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__super focus&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__super focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__super focus\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__super focus\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__super focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__super focus\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__super focus\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -566,16 +566,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Active state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__super active">Anchor Tag</a>
-<button class="btn btn__super active">Button Tag</button>
+<button class="btn btn__super active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super active">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__super active&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__super active&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__super active&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;submit&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__super active&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__super active\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__super active\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__super active\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__super active\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__super active\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;submit\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__super active\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -606,7 +606,7 @@ input.btn::-moz-focus-inner {
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Anchor Tag
 </a>
-<button class="btn">
+<button class="btn" title="Test button">
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Button Tag
 </button>
@@ -616,7 +616,7 @@ input.btn::-moz-focus-inner {
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Anchor Tag
 </a>
-<button class="btn btn__secondary">
+<button class="btn btn__secondary" title="Test button">
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Button Tag
 </button>
@@ -626,7 +626,7 @@ input.btn::-moz-focus-inner {
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Anchor Tag
 </a>
-<button class="btn btn__warning">
+<button class="btn btn__warning" title="Test button">
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Button Tag
 </button>
@@ -636,11 +636,11 @@ input.btn::-moz-focus-inner {
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Anchor Tag
 </a>
-<button class="btn btn__disabled">
+<button class="btn btn__disabled" title="Test button">
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Button Tag
 </button>
-<button class="btn" disabled>
+<button class="btn" disabled title="Test button">
     <span class="btn_icon__left cf-icon cf-icon-left"></span>
     Button Tag w/ disabled attr
 </button>
@@ -651,7 +651,7 @@ input.btn::-moz-focus-inner {
     &lt;span class=&quot;btn_icon__left cf-icon cf-icon-left&quot;&gt;&lt;/span&gt;
     Anchor Tag
 &lt;/a&gt;
-&lt;button class=&quot;btn&quot;&gt;
+&lt;button class=&quot;btn&quot; title=&quot;Test button&quot;&gt;
     &lt;span class=&quot;btn_icon__left cf-icon cf-icon-left&quot;&gt;&lt;/span&gt;
     Button Tag
 &lt;/button&gt;
@@ -661,7 +661,7 @@ input.btn::-moz-focus-inner {
     &lt;span class=&quot;btn_icon__left cf-icon cf-icon-left&quot;&gt;&lt;/span&gt;
     Anchor Tag
 &lt;/a&gt;
-&lt;button class=&quot;btn btn__secondary&quot;&gt;
+&lt;button class=&quot;btn btn__secondary&quot; title=&quot;Test button&quot;&gt;
     &lt;span class=&quot;btn_icon__left cf-icon cf-icon-left&quot;&gt;&lt;/span&gt;
     Button Tag
 &lt;/button&gt;
@@ -671,7 +671,7 @@ input.btn::-moz-focus-inner {
     &lt;span class=&quot;btn_icon__left cf-icon cf-icon-left&quot;&gt;&lt;/span&gt;
     Anchor Tag
 &lt;/a&gt;
-&lt;button class=&quot;btn btn__warning&quot;&gt;
+&lt;button class=&quot;btn btn__warning&quot; title=&quot;Test button&quot;&gt;
     &lt;span class=&quot;btn_icon__left cf-icon cf-icon-left&quot;&gt;&lt;/span&gt;
     Button Tag
 &lt;/button&gt;
@@ -681,16 +681,16 @@ input.btn::-moz-focus-inner {
     &lt;span class=&quot;btn_icon__left cf-icon cf-icon-left&quot;&gt;&lt;/span&gt;
     Anchor Tag
 &lt;/a&gt;
-&lt;button class=&quot;btn btn__disabled&quot;&gt;
+&lt;button class=&quot;btn btn__disabled&quot; title=&quot;Test button&quot;&gt;
     &lt;span class=&quot;btn_icon__left cf-icon cf-icon-left&quot;&gt;&lt;/span&gt;
     Button Tag
 &lt;/button&gt;
-&lt;button class=&quot;btn&quot; disabled&gt;
+&lt;button class=&quot;btn&quot; disabled title=&quot;Test button&quot;&gt;
     &lt;span class=&quot;btn_icon__left cf-icon cf-icon-left&quot;&gt;&lt;/span&gt;
     Button Tag w/ disabled attr
 &lt;/button&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Anchor Tag\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Button Tag\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__secondary\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Anchor Tag\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__secondary\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Button Tag\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__warning\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Anchor Tag\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__warning\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Button Tag\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__disabled\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Anchor Tag\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__disabled\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Button Tag\n&lt;/button&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot; disabled&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Button Tag w/ disabled attr\n&lt;/button&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Anchor Tag\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Button Tag\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__secondary\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Anchor Tag\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__secondary\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Button Tag\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__warning\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Anchor Tag\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__warning\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Button Tag\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__disabled\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Anchor Tag\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__disabled\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Button Tag\n&lt;/button&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot; disabled title=\&amp;quot;Test button\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;btn_icon__left cf-icon cf-icon-left\&amp;quot;&gt;&lt;/span&gt;\n    Button Tag w/ disabled attr\n&lt;/button&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -702,7 +702,7 @@ input.btn::-moz-focus-inner {
     Anchor Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </a>
-<button class="btn">
+<button class="btn" title="Test button">
     Button Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </button>
@@ -712,7 +712,7 @@ input.btn::-moz-focus-inner {
     Anchor Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </a>
-<button class="btn btn__secondary">
+<button class="btn btn__secondary" title="Test button">
     Button Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </button>
@@ -722,7 +722,7 @@ input.btn::-moz-focus-inner {
     Anchor Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </a>
-<button class="btn btn__warning">
+<button class="btn btn__warning" title="Test button">
     Button Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </button>
@@ -732,11 +732,11 @@ input.btn::-moz-focus-inner {
     Anchor Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </a>
-<button class="btn btn__disabled">
+<button class="btn btn__disabled" title="Test button">
     Button Tag
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </button>
-<button class="btn" disabled>
+<button class="btn" disabled title="Test button">
     Button Tag w/ disabled attr
     <span class="btn_icon__right cf-icon cf-icon-right"></span>
 </button>
@@ -747,7 +747,7 @@ input.btn::-moz-focus-inner {
     Anchor Tag
     &lt;span class=&quot;btn_icon__right cf-icon cf-icon-right&quot;&gt;&lt;/span&gt;
 &lt;/a&gt;
-&lt;button class=&quot;btn&quot;&gt;
+&lt;button class=&quot;btn&quot; title=&quot;Test button&quot;&gt;
     Button Tag
     &lt;span class=&quot;btn_icon__right cf-icon cf-icon-right&quot;&gt;&lt;/span&gt;
 &lt;/button&gt;
@@ -757,7 +757,7 @@ input.btn::-moz-focus-inner {
     Anchor Tag
     &lt;span class=&quot;btn_icon__right cf-icon cf-icon-right&quot;&gt;&lt;/span&gt;
 &lt;/a&gt;
-&lt;button class=&quot;btn btn__secondary&quot;&gt;
+&lt;button class=&quot;btn btn__secondary&quot; title=&quot;Test button&quot;&gt;
     Button Tag
     &lt;span class=&quot;btn_icon__right cf-icon cf-icon-right&quot;&gt;&lt;/span&gt;
 &lt;/button&gt;
@@ -767,7 +767,7 @@ input.btn::-moz-focus-inner {
     Anchor Tag
     &lt;span class=&quot;btn_icon__right cf-icon cf-icon-right&quot;&gt;&lt;/span&gt;
 &lt;/a&gt;
-&lt;button class=&quot;btn btn__warning&quot;&gt;
+&lt;button class=&quot;btn btn__warning&quot; title=&quot;Test button&quot;&gt;
     Button Tag
     &lt;span class=&quot;btn_icon__right cf-icon cf-icon-right&quot;&gt;&lt;/span&gt;
 &lt;/button&gt;
@@ -777,16 +777,16 @@ input.btn::-moz-focus-inner {
     Anchor Tag
     &lt;span class=&quot;btn_icon__right cf-icon cf-icon-right&quot;&gt;&lt;/span&gt;
 &lt;/a&gt;
-&lt;button class=&quot;btn btn__disabled&quot;&gt;
+&lt;button class=&quot;btn btn__disabled&quot; title=&quot;Test button&quot;&gt;
     Button Tag
     &lt;span class=&quot;btn_icon__right cf-icon cf-icon-right&quot;&gt;&lt;/span&gt;
 &lt;/button&gt;
-&lt;button class=&quot;btn&quot; disabled&gt;
+&lt;button class=&quot;btn&quot; disabled title=&quot;Test button&quot;&gt;
     Button Tag w/ disabled attr
     &lt;span class=&quot;btn_icon__right cf-icon cf-icon-right&quot;&gt;&lt;/span&gt;
 &lt;/button&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn\&amp;quot;&gt;\n    Anchor Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot;&gt;\n    Button Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__secondary\&amp;quot;&gt;\n    Anchor Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__secondary\&amp;quot;&gt;\n    Button Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__warning\&amp;quot;&gt;\n    Anchor Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__warning\&amp;quot;&gt;\n    Button Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__disabled\&amp;quot;&gt;\n    Anchor Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__disabled\&amp;quot;&gt;\n    Button Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot; disabled&gt;\n    Button Tag w/ disabled attr\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn\&amp;quot;&gt;\n    Anchor Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    Button Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__secondary\&amp;quot;&gt;\n    Anchor Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__secondary\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    Button Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__warning\&amp;quot;&gt;\n    Anchor Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__warning\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    Button Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__disabled\&amp;quot;&gt;\n    Anchor Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__disabled\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    Button Tag\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot; disabled title=\&amp;quot;Test button\&amp;quot;&gt;\n    Button Tag w/ disabled attr\n    &lt;span class=\&amp;quot;btn_icon__right cf-icon cf-icon-right\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -798,7 +798,7 @@ input.btn::-moz-focus-inner {
     <span class="u-visually-hidden">Search</span>
     <span class="cf-icon cf-icon-search"></span>
 </a>
-<button class="btn">
+<button class="btn" title="Test button">
     <span class="u-visually-hidden">Search</span>
     <span class="cf-icon cf-icon-search"></span>
 </button>
@@ -809,12 +809,12 @@ input.btn::-moz-focus-inner {
     &lt;span class=&quot;u-visually-hidden&quot;&gt;Search&lt;/span&gt;
     &lt;span class=&quot;cf-icon cf-icon-search&quot;&gt;&lt;/span&gt;
 &lt;/a&gt;
-&lt;button class=&quot;btn&quot;&gt;
+&lt;button class=&quot;btn&quot; title=&quot;Test button&quot;&gt;
     &lt;span class=&quot;u-visually-hidden&quot;&gt;Search&lt;/span&gt;
     &lt;span class=&quot;cf-icon cf-icon-search&quot;&gt;&lt;/span&gt;
 &lt;/button&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;u-visually-hidden\&amp;quot;&gt;Search&lt;/span&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-search\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;u-visually-hidden\&amp;quot;&gt;Search&lt;/span&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-search\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;u-visually-hidden\&amp;quot;&gt;Search&lt;/span&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-search\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;button class=\&amp;quot;btn\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;u-visually-hidden\&amp;quot;&gt;Search&lt;/span&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-search\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
                 <ul class="docs-notes">
@@ -876,9 +876,9 @@ input.btn::-moz-focus-inner {
 <a href="#" class="btn btn__grouped-last">Anchor 3</a>
 <br>
 <br>
-<button class="btn btn__grouped-first">Button 1</button>
-<button class="btn btn__grouped">Button 2</button>
-<button class="btn btn__grouped-last">Button 3</button>
+<button class="btn btn__grouped-first" title="Test button">Button 1</button>
+<button class="btn btn__grouped" title="Test button">Button 2</button>
+<button class="btn btn__grouped-last" title="Test button">Button 3</button>
 <br>
 <br>
 <input type="button" value="Input 1" class="btn btn__grouped-first">
@@ -892,16 +892,16 @@ input.btn::-moz-focus-inner {
 &lt;a href=&quot;#&quot; class=&quot;btn btn__grouped-last&quot;&gt;Anchor 3&lt;/a&gt;
 &lt;br&gt;
 &lt;br&gt;
-&lt;button class=&quot;btn btn__grouped-first&quot;&gt;Button 1&lt;/button&gt;
-&lt;button class=&quot;btn btn__grouped&quot;&gt;Button 2&lt;/button&gt;
-&lt;button class=&quot;btn btn__grouped-last&quot;&gt;Button 3&lt;/button&gt;
+&lt;button class=&quot;btn btn__grouped-first&quot; title=&quot;Test button&quot;&gt;Button 1&lt;/button&gt;
+&lt;button class=&quot;btn btn__grouped&quot; title=&quot;Test button&quot;&gt;Button 2&lt;/button&gt;
+&lt;button class=&quot;btn btn__grouped-last&quot; title=&quot;Test button&quot;&gt;Button 3&lt;/button&gt;
 &lt;br&gt;
 &lt;br&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input 1&quot; class=&quot;btn btn__grouped-first&quot;&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input 2&quot; class=&quot;btn btn__grouped&quot;&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input 3&quot; class=&quot;btn btn__grouped-last&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first\&amp;quot;&gt;Anchor 1&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped\&amp;quot;&gt;Anchor 2&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last\&amp;quot;&gt;Anchor 3&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first\&amp;quot;&gt;Button 1&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped\&amp;quot;&gt;Button 2&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last\&amp;quot;&gt;Button 3&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input 1\&amp;quot; class=\&amp;quot;btn btn__grouped-first\&amp;quot;&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input 2\&amp;quot; class=\&amp;quot;btn btn__grouped\&amp;quot;&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input 3\&amp;quot; class=\&amp;quot;btn btn__grouped-last\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first\&amp;quot;&gt;Anchor 1&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped\&amp;quot;&gt;Anchor 2&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last\&amp;quot;&gt;Anchor 3&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button 1&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button 2&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button 3&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input 1\&amp;quot; class=\&amp;quot;btn btn__grouped-first\&amp;quot;&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input 2\&amp;quot; class=\&amp;quot;btn btn__grouped\&amp;quot;&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input 3\&amp;quot; class=\&amp;quot;btn btn__grouped-last\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -914,9 +914,9 @@ input.btn::-moz-focus-inner {
 <a href="#" class="btn btn__grouped-last btn__super">Anchor 3</a>
 <br>
 <br>
-<button class="btn btn__grouped-first btn__super">Button 1</button>
-<button class="btn btn__grouped btn__super">Button 2</button>
-<button class="btn btn__grouped-last btn__super">Button 3</button>
+<button class="btn btn__grouped-first btn__super" title="Test button">Button 1</button>
+<button class="btn btn__grouped btn__super" title="Test button">Button 2</button>
+<button class="btn btn__grouped-last btn__super" title="Test button">Button 3</button>
 <br>
 <br>
 <input type="button" value="Input 1" class="btn btn__grouped-first btn__super">
@@ -930,16 +930,16 @@ input.btn::-moz-focus-inner {
 &lt;a href=&quot;#&quot; class=&quot;btn btn__grouped-last btn__super&quot;&gt;Anchor 3&lt;/a&gt;
 &lt;br&gt;
 &lt;br&gt;
-&lt;button class=&quot;btn btn__grouped-first btn__super&quot;&gt;Button 1&lt;/button&gt;
-&lt;button class=&quot;btn btn__grouped btn__super&quot;&gt;Button 2&lt;/button&gt;
-&lt;button class=&quot;btn btn__grouped-last btn__super&quot;&gt;Button 3&lt;/button&gt;
+&lt;button class=&quot;btn btn__grouped-first btn__super&quot; title=&quot;Test button&quot;&gt;Button 1&lt;/button&gt;
+&lt;button class=&quot;btn btn__grouped btn__super&quot; title=&quot;Test button&quot;&gt;Button 2&lt;/button&gt;
+&lt;button class=&quot;btn btn__grouped-last btn__super&quot; title=&quot;Test button&quot;&gt;Button 3&lt;/button&gt;
 &lt;br&gt;
 &lt;br&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input 1&quot; class=&quot;btn btn__grouped-first btn__super&quot;&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input 2&quot; class=&quot;btn btn__grouped btn__super&quot;&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input 3&quot; class=&quot;btn btn__grouped-last btn__super&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first btn__super\&amp;quot;&gt;Anchor 1&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped btn__super\&amp;quot;&gt;Anchor 2&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__super\&amp;quot;&gt;Anchor 3&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first btn__super\&amp;quot;&gt;Button 1&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped btn__super\&amp;quot;&gt;Button 2&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__super\&amp;quot;&gt;Button 3&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input 1\&amp;quot; class=\&amp;quot;btn btn__grouped-first btn__super\&amp;quot;&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input 2\&amp;quot; class=\&amp;quot;btn btn__grouped btn__super\&amp;quot;&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input 3\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__super\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first btn__super\&amp;quot;&gt;Anchor 1&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped btn__super\&amp;quot;&gt;Anchor 2&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__super\&amp;quot;&gt;Anchor 3&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first btn__super\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button 1&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped btn__super\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button 2&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__super\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button 3&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input 1\&amp;quot; class=\&amp;quot;btn btn__grouped-first btn__super\&amp;quot;&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input 2\&amp;quot; class=\&amp;quot;btn btn__grouped btn__super\&amp;quot;&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input 3\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__super\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -993,8 +993,8 @@ input.btn::-moz-focus-inner {
 </a>
 <br>
 <br>
-<button class="btn btn__grouped-first">Button</button>
-<button class="btn btn__grouped-last btn__compound-action">
+<button class="btn btn__grouped-first" title="Test button">Button</button>
+<button class="btn btn__grouped-last btn__compound-action" title="Test button">
     <span class="cf-icon cf-icon-down btn__grouped-last"></span>
 </button>
 <br>
@@ -1005,8 +1005,8 @@ input.btn::-moz-focus-inner {
 </a>
 <br>
 <br>
-<button class="btn btn__grouped-first btn__secondary">Button</button>
-<button class="btn btn__grouped-last btn__secondary btn__compound-action">
+<button class="btn btn__grouped-first btn__secondary" title="Test button">Button</button>
+<button class="btn btn__grouped-last btn__secondary btn__compound-action" title="Test button">
     <span class="cf-icon cf-icon-down btn__grouped-last"></span>
 </button>
 <br>
@@ -1017,8 +1017,8 @@ input.btn::-moz-focus-inner {
 </a>
 <br>
 <br>
-<button class="btn btn__grouped-first btn__warning">Button</button>
-<button class="btn btn__grouped-last btn__warning btn__compound-action">
+<button class="btn btn__grouped-first btn__warning" title="Test button">Button</button>
+<button class="btn btn__grouped-last btn__warning btn__compound-action" title="Test button">
     <span class="cf-icon cf-icon-down btn__grouped-last"></span>
 </button>
 <br>
@@ -1029,14 +1029,14 @@ input.btn::-moz-focus-inner {
 </a>
 <br>
 <br>
-<button class="btn btn__grouped-first btn__disabled">Button</button>
-<button class="btn btn__grouped-last btn__disabled btn__compound-action">
+<button class="btn btn__grouped-first btn__disabled" title="Test button">Button</button>
+<button class="btn btn__grouped-last btn__disabled btn__compound-action" title="Test button">
     <span class="cf-icon cf-icon-down btn__grouped-last"></span>
 </button>
 <br>
 <br>
-<button class="btn btn__grouped-first" disabled>Button w/ disabled attr</button>
-<button class="btn btn__grouped-last btn__compound-action" disabled>
+<button class="btn btn__grouped-first" disabled title="Test button">Button w/ disabled attr</button>
+<button class="btn btn__grouped-last btn__compound-action" disabled title="Test button">
     <span class="cf-icon cf-icon-down btn__grouped-last"></span>
 </button>
 <br>
@@ -1047,8 +1047,8 @@ input.btn::-moz-focus-inner {
 </a>
 <br>
 <br>
-<button class="btn btn__grouped-first btn__super">Button</button>
-<button class="btn btn__grouped-last btn__super btn__compound-action">
+<button class="btn btn__grouped-first btn__super" title="Test button">Button</button>
+<button class="btn btn__grouped-last btn__super btn__compound-action" title="Test button">
     <span class="cf-icon cf-icon-down btn__grouped-last"></span>
 </button>
 
@@ -1060,8 +1060,8 @@ input.btn::-moz-focus-inner {
 &lt;/a&gt;
 &lt;br&gt;
 &lt;br&gt;
-&lt;button class=&quot;btn btn__grouped-first&quot;&gt;Button&lt;/button&gt;
-&lt;button class=&quot;btn btn__grouped-last btn__compound-action&quot;&gt;
+&lt;button class=&quot;btn btn__grouped-first&quot; title=&quot;Test button&quot;&gt;Button&lt;/button&gt;
+&lt;button class=&quot;btn btn__grouped-last btn__compound-action&quot; title=&quot;Test button&quot;&gt;
     &lt;span class=&quot;cf-icon cf-icon-down btn__grouped-last&quot;&gt;&lt;/span&gt;
 &lt;/button&gt;
 &lt;br&gt;
@@ -1072,8 +1072,8 @@ input.btn::-moz-focus-inner {
 &lt;/a&gt;
 &lt;br&gt;
 &lt;br&gt;
-&lt;button class=&quot;btn btn__grouped-first btn__secondary&quot;&gt;Button&lt;/button&gt;
-&lt;button class=&quot;btn btn__grouped-last btn__secondary btn__compound-action&quot;&gt;
+&lt;button class=&quot;btn btn__grouped-first btn__secondary&quot; title=&quot;Test button&quot;&gt;Button&lt;/button&gt;
+&lt;button class=&quot;btn btn__grouped-last btn__secondary btn__compound-action&quot; title=&quot;Test button&quot;&gt;
     &lt;span class=&quot;cf-icon cf-icon-down btn__grouped-last&quot;&gt;&lt;/span&gt;
 &lt;/button&gt;
 &lt;br&gt;
@@ -1084,8 +1084,8 @@ input.btn::-moz-focus-inner {
 &lt;/a&gt;
 &lt;br&gt;
 &lt;br&gt;
-&lt;button class=&quot;btn btn__grouped-first btn__warning&quot;&gt;Button&lt;/button&gt;
-&lt;button class=&quot;btn btn__grouped-last btn__warning btn__compound-action&quot;&gt;
+&lt;button class=&quot;btn btn__grouped-first btn__warning&quot; title=&quot;Test button&quot;&gt;Button&lt;/button&gt;
+&lt;button class=&quot;btn btn__grouped-last btn__warning btn__compound-action&quot; title=&quot;Test button&quot;&gt;
     &lt;span class=&quot;cf-icon cf-icon-down btn__grouped-last&quot;&gt;&lt;/span&gt;
 &lt;/button&gt;
 &lt;br&gt;
@@ -1096,14 +1096,14 @@ input.btn::-moz-focus-inner {
 &lt;/a&gt;
 &lt;br&gt;
 &lt;br&gt;
-&lt;button class=&quot;btn btn__grouped-first btn__disabled&quot;&gt;Button&lt;/button&gt;
-&lt;button class=&quot;btn btn__grouped-last btn__disabled btn__compound-action&quot;&gt;
+&lt;button class=&quot;btn btn__grouped-first btn__disabled&quot; title=&quot;Test button&quot;&gt;Button&lt;/button&gt;
+&lt;button class=&quot;btn btn__grouped-last btn__disabled btn__compound-action&quot; title=&quot;Test button&quot;&gt;
     &lt;span class=&quot;cf-icon cf-icon-down btn__grouped-last&quot;&gt;&lt;/span&gt;
 &lt;/button&gt;
 &lt;br&gt;
 &lt;br&gt;
-&lt;button class=&quot;btn btn__grouped-first&quot; disabled&gt;Button w/ disabled attr&lt;/button&gt;
-&lt;button class=&quot;btn btn__grouped-last btn__compound-action&quot; disabled&gt;
+&lt;button class=&quot;btn btn__grouped-first&quot; disabled title=&quot;Test button&quot;&gt;Button w/ disabled attr&lt;/button&gt;
+&lt;button class=&quot;btn btn__grouped-last btn__compound-action&quot; disabled title=&quot;Test button&quot;&gt;
     &lt;span class=&quot;cf-icon cf-icon-down btn__grouped-last&quot;&gt;&lt;/span&gt;
 &lt;/button&gt;
 &lt;br&gt;
@@ -1114,12 +1114,12 @@ input.btn::-moz-focus-inner {
 &lt;/a&gt;
 &lt;br&gt;
 &lt;br&gt;
-&lt;button class=&quot;btn btn__grouped-first btn__super&quot;&gt;Button&lt;/button&gt;
-&lt;button class=&quot;btn btn__grouped-last btn__super btn__compound-action&quot;&gt;
+&lt;button class=&quot;btn btn__grouped-first btn__super&quot; title=&quot;Test button&quot;&gt;Button&lt;/button&gt;
+&lt;button class=&quot;btn btn__grouped-last btn__super btn__compound-action&quot; title=&quot;Test button&quot;&gt;
     &lt;span class=&quot;cf-icon cf-icon-down btn__grouped-last&quot;&gt;&lt;/span&gt;
 &lt;/button&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first\&amp;quot;&gt;Anchor&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first\&amp;quot;&gt;Button&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first btn__secondary\&amp;quot;&gt;Anchor&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__secondary btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first btn__secondary\&amp;quot;&gt;Button&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__secondary btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first btn__warning\&amp;quot;&gt;Anchor&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__warning btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first btn__warning\&amp;quot;&gt;Button&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__warning btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first btn__disabled\&amp;quot;&gt;Anchor&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__disabled btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first btn__disabled\&amp;quot;&gt;Button&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__disabled btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first\&amp;quot; disabled&gt;Button w/ disabled attr&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__compound-action\&amp;quot; disabled&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first btn__super\&amp;quot;&gt;Anchor&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__super btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first btn__super\&amp;quot;&gt;Button&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__super btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first\&amp;quot;&gt;Anchor&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__compound-action\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first btn__secondary\&amp;quot;&gt;Anchor&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__secondary btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first btn__secondary\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__secondary btn__compound-action\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first btn__warning\&amp;quot;&gt;Anchor&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__warning btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first btn__warning\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__warning btn__compound-action\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first btn__disabled\&amp;quot;&gt;Anchor&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__disabled btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first btn__disabled\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__disabled btn__compound-action\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first\&amp;quot; disabled title=\&amp;quot;Test button\&amp;quot;&gt;Button w/ disabled attr&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__compound-action\&amp;quot; disabled title=\&amp;quot;Test button\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-first btn__super\&amp;quot;&gt;Anchor&lt;/a&gt;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__grouped-last btn__super btn__compound-action\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/a&gt;\n&lt;br&gt;\n&lt;br&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-first btn__super\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button&lt;/button&gt;\n&lt;button class=\&amp;quot;btn btn__grouped-last btn__super btn__compound-action\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;\n    &lt;span class=\&amp;quot;cf-icon cf-icon-down btn__grouped-last\&amp;quot;&gt;&lt;/span&gt;\n&lt;/button&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -1180,16 +1180,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Default state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__link">Anchor Tag</a>
-<button class="btn btn__link">Button Tag</button>
+<button class="btn btn__link" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__link&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__link&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__link&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__link&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -1198,16 +1198,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Hovered state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__link hover">Anchor Tag</a>
-<button class="btn btn__link hover">Button Tag</button>
+<button class="btn btn__link hover" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link hover">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__link hover&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__link hover&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__link hover&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__link hover&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link hover\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link hover\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link hover\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link hover\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link hover\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link hover\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -1216,16 +1216,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Focused state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__link focus">Anchor Tag</a>
-<button class="btn btn__link focus">Button Tag</button>
+<button class="btn btn__link focus" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link focus">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__link focus&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__link focus&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__link focus&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__link focus&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link focus\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link focus\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link focus\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link focus\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -1234,16 +1234,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Active state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__link active">Anchor Tag</a>
-<button class="btn btn__link active">Button Tag</button>
+<button class="btn btn__link active" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link active">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__link active&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__link active&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__link active&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__link active&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link active\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link active\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link active\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link active\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link active\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link active\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -1299,16 +1299,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Default state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__link btn__secondary">Anchor Tag</a>
-<button class="btn btn__link btn__secondary">Button Tag</button>
+<button class="btn btn__link btn__secondary" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__secondary">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__link btn__secondary&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__link btn__secondary&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__link btn__secondary&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__link btn__secondary&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__secondary\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__secondary\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -1317,16 +1317,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Hovered state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__link btn__secondary hover">Anchor Tag</a>
-<button class="btn btn__link btn__secondary hover">Button Tag</button>
+<button class="btn btn__link btn__secondary hover" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__secondary hover">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__link btn__secondary hover&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__link btn__secondary hover&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__link btn__secondary hover&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__link btn__secondary hover&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary hover\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__secondary hover\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary hover\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary hover\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__secondary hover\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary hover\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -1335,16 +1335,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Focused state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__link btn__secondary focus">Anchor Tag</a>
-<button class="btn btn__link btn__secondary focus">Button Tag</button>
+<button class="btn btn__link btn__secondary focus" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__secondary focus">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__link btn__secondary focus&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__link btn__secondary focus&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__link btn__secondary focus&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__link btn__secondary focus&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__secondary focus\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary focus\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__secondary focus\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary focus\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -1353,16 +1353,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Active state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__link btn__secondary active">Anchor Tag</a>
-<button class="btn btn__link btn__secondary active">Button Tag</button>
+<button class="btn btn__link btn__secondary active" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__secondary active">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__link btn__secondary active&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__link btn__secondary active&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__link btn__secondary active&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__link btn__secondary active&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary active\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__secondary active\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary active\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary active\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__secondary active\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__secondary active\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -1404,16 +1404,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Default state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__link btn__warning">Anchor Tag</a>
-<button class="btn btn__link btn__warning">Button Tag</button>
+<button class="btn btn__link btn__warning" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__warning">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__link btn__warning&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__link btn__warning&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__link btn__warning&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__link btn__warning&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__warning\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__warning\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__warning\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__warning\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__warning\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__warning\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -1422,16 +1422,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Hovered state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__link btn__warning hover">Anchor Tag</a>
-<button class="btn btn__link btn__warning hover">Button Tag</button>
+<button class="btn btn__link btn__warning hover" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__warning hover">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__link btn__warning hover&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__link btn__warning hover&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__link btn__warning hover&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__link btn__warning hover&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__warning hover\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__warning hover\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__warning hover\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__warning hover\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__warning hover\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__warning hover\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -1440,16 +1440,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Focused state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__link btn__warning focus">Anchor Tag</a>
-<button class="btn btn__link btn__warning focus">Button Tag</button>
+<button class="btn btn__link btn__warning focus" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__warning focus">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__link btn__warning focus&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__link btn__warning focus&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__link btn__warning focus&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__link btn__warning focus&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__warning focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__warning focus\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__warning focus\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__warning focus\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__warning focus\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__warning focus\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>
@@ -1458,16 +1458,16 @@ input.btn::-moz-focus-inner {
               <h3 class="docs-pattern_header">Active state</h3>
               <section class="docs-pattern_pattern">
 <a href="#" class="btn btn__link btn__warning active">Anchor Tag</a>
-<button class="btn btn__link btn__warning active">Button Tag</button>
+<button class="btn btn__link btn__warning active" title="Test button">Button Tag</button>
 <input type="button" value="Input Tag" class="btn btn__link btn__warning active">
 
               </section>
               <footer class="docs-pattern_footer">
                 <pre class="docs-code docs-pattern_markup"><code data-language="html">&lt;a href=&quot;#&quot; class=&quot;btn btn__link btn__warning active&quot;&gt;Anchor Tag&lt;/a&gt;
-&lt;button class=&quot;btn btn__link btn__warning active&quot;&gt;Button Tag&lt;/button&gt;
+&lt;button class=&quot;btn btn__link btn__warning active&quot; title=&quot;Test button&quot;&gt;Button Tag&lt;/button&gt;
 &lt;input type=&quot;button&quot; value=&quot;Input Tag&quot; class=&quot;btn btn__link btn__warning active&quot;&gt;</code></pre>
                 <form action="http://codepen.io/pen/define" method="POST" target="_blank" class="docs-pattern_footer-edit">
-                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__warning active\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__warning active\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__warning active\&amp;quot;&gt;\n&amp;quot;}">
+                  <input type="hidden" name="data" value="{&amp;quot;css&amp;quot;:&amp;quot;body { padding: 1em; }&amp;quot;,&amp;quot;css_external&amp;quot;:&amp;quot;http://cfpb.github.io/cf-buttons/docs/static/css/main.css&amp;quot;,&amp;quot;html&amp;quot;:&amp;quot;\n&lt;a href=\&amp;quot;#\&amp;quot; class=\&amp;quot;btn btn__link btn__warning active\&amp;quot;&gt;Anchor Tag&lt;/a&gt;\n&lt;button class=\&amp;quot;btn btn__link btn__warning active\&amp;quot; title=\&amp;quot;Test button\&amp;quot;&gt;Button Tag&lt;/button&gt;\n&lt;input type=\&amp;quot;button\&amp;quot; value=\&amp;quot;Input Tag\&amp;quot; class=\&amp;quot;btn btn__link btn__warning active\&amp;quot;&gt;\n&amp;quot;}">
                   <input type="submit" value="edit on codepen.io" class="docs-pattern_footer-edit-btn">
                 </form>
               </footer>

--- a/docs/static/css/main.css
+++ b/docs/static/css/main.css
@@ -53,23 +53,23 @@
   patterns:
   - name: Default state
     markup: |
-      <a href="#" class="btn">Anchor Tag</a>
-      <button class="btn">Button Tag</button>
+      <a href="#" class="btn" title="Test button">Anchor Tag</a>
+      <button class="btn" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn">
   - name: Hovered state
     markup: |
-      <a href="#" class="btn hover">Anchor Tag</a>
-      <button class="btn hover">Button Tag</button>
+      <a href="#" class="btn hover" title="Test button">Anchor Tag</a>
+      <button class="btn hover" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn hover">
   - name: Focused state
     markup: |
-      <a href="#" class="btn focus">Anchor Tag</a>
-      <button class="btn focus">Button Tag</button>
+      <a href="#" class="btn focus" title="Test button">Anchor Tag</a>
+      <button class="btn focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn focus">
   - name: Active state
     markup: |
-      <a href="#" class="btn active">Anchor Tag</a>
-      <button class="btn active">Button Tag</button>
+      <a href="#" class="btn active" title="Test button">Anchor Tag</a>
+      <button class="btn active" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn active">
   tags:
   - cf-buttons
@@ -144,22 +144,22 @@ input.btn::-moz-focus-inner {
   - name: Default state
     markup: |
       <a href="#" class="btn btn__secondary">Anchor Tag</a>
-      <button class="btn btn__secondary">Button Tag</button>
+      <button class="btn btn__secondary" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__secondary">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__secondary hover">Anchor Tag</a>
-      <button class="btn btn__secondary hover">Button Tag</button>
+      <button class="btn btn__secondary hover" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__secondary hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__secondary focus">Anchor Tag</a>
-      <button class="btn btn__secondary focus">Button Tag</button>
+      <button class="btn btn__secondary focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__secondary focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__secondary active">Anchor Tag</a>
-      <button class="btn btn__secondary active">Button Tag</button>
+      <button class="btn btn__secondary active" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__secondary active">
   tags:
   - cf-buttons
@@ -193,22 +193,22 @@ input.btn::-moz-focus-inner {
   - name: Default state
     markup: |
       <a href="#" class="btn btn__warning">Anchor Tag</a>
-      <button class="btn btn__warning">Button Tag</button>
+      <button class="btn btn__warning" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__warning">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__warning hover">Anchor Tag</a>
-      <button class="btn btn__warning hover">Button Tag</button>
+      <button class="btn btn__warning hover" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__warning hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__warning focus">Anchor Tag</a>
-      <button class="btn btn__warning focus">Button Tag</button>
+      <button class="btn btn__warning focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__warning focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__warning active">Anchor Tag</a>
-      <button class="btn btn__warning active">Button Tag</button>
+      <button class="btn btn__warning active" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__warning active">
   tags:
   - cf-buttons
@@ -244,15 +244,15 @@ input.btn::-moz-focus-inner {
   - name: Default/hovered/active state
     markup: |
       <a href="#" class="btn btn__disabled">Anchor Tag</a>
-      <button class="btn btn__disabled">Button Tag</button>
+      <button class="btn btn__disabled" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__disabled">
-      <button class="btn" disabled>Button Tag w/ disabled attr</button>
+      <button class="btn" disabled title="Test button">Button Tag w/ disabled attr</button>
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__disabled focus">Anchor Tag</a>
-      <button class="btn btn__disabled focus">Button Tag</button>
+      <button class="btn btn__disabled focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__disabled focus">
-      <button class="btn focus" disabled>Button Tag w/ disabled attr</button>
+      <button class="btn focus" disabled title="Test button">Button Tag w/ disabled attr</button>
   tags:
   - cf-buttons
 */
@@ -292,22 +292,22 @@ input.btn::-moz-focus-inner {
   - name: Default state
     markup: |
       <a href="#" class="btn btn__super">Anchor Tag</a>
-      <button class="btn btn__super">Button Tag</button>
+      <button class="btn btn__super" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__super">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__super hover">Anchor Tag</a>
-      <button class="btn btn__super hover">Button Tag</button>
+      <button class="btn btn__super hover" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__super hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__super focus">Anchor Tag</a>
-      <button class="btn btn__super focus">Button Tag</button>
+      <button class="btn btn__super focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__super focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__super active">Anchor Tag</a>
-      <button class="btn btn__super active">Button Tag</button>
+      <button class="btn btn__super active" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__super active">
   tags:
   - cf-buttons
@@ -334,7 +334,7 @@ input.btn::-moz-focus-inner {
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Anchor Tag
       </a>
-      <button class="btn">
+      <button class="btn" title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag
       </button>
@@ -344,7 +344,7 @@ input.btn::-moz-focus-inner {
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Anchor Tag
       </a>
-      <button class="btn btn__secondary">
+      <button class="btn btn__secondary" title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag
       </button>
@@ -354,7 +354,7 @@ input.btn::-moz-focus-inner {
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Anchor Tag
       </a>
-      <button class="btn btn__warning">
+      <button class="btn btn__warning" title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag
       </button>
@@ -364,11 +364,11 @@ input.btn::-moz-focus-inner {
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Anchor Tag
       </a>
-      <button class="btn btn__disabled">
+      <button class="btn btn__disabled" title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag
       </button>
-      <button class="btn" disabled>
+      <button class="btn" disabled title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag w/ disabled attr
       </button>
@@ -378,7 +378,7 @@ input.btn::-moz-focus-inner {
           Anchor Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </a>
-      <button class="btn">
+      <button class="btn" title="Test button">
           Button Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
@@ -388,7 +388,7 @@ input.btn::-moz-focus-inner {
           Anchor Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </a>
-      <button class="btn btn__secondary">
+      <button class="btn btn__secondary" title="Test button">
           Button Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
@@ -398,7 +398,7 @@ input.btn::-moz-focus-inner {
           Anchor Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </a>
-      <button class="btn btn__warning">
+      <button class="btn btn__warning" title="Test button">
           Button Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
@@ -408,11 +408,11 @@ input.btn::-moz-focus-inner {
           Anchor Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </a>
-      <button class="btn btn__disabled">
+      <button class="btn btn__disabled" title="Test button">
           Button Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
-      <button class="btn" disabled>
+      <button class="btn" disabled title="Test button">
           Button Tag w/ disabled attr
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
@@ -422,7 +422,7 @@ input.btn::-moz-focus-inner {
           <span class="u-visually-hidden">Search</span>
           <span class="cf-icon cf-icon-search"></span>
       </a>
-      <button class="btn">
+      <button class="btn" title="Test button">
           <span class="u-visually-hidden">Search</span>
           <span class="cf-icon cf-icon-search"></span>
       </button>
@@ -483,9 +483,9 @@ input.btn::-moz-focus-inner {
       <a href="#" class="btn btn__grouped-last">Anchor 3</a>
       <br>
       <br>
-      <button class="btn btn__grouped-first">Button 1</button>
-      <button class="btn btn__grouped">Button 2</button>
-      <button class="btn btn__grouped-last">Button 3</button>
+      <button class="btn btn__grouped-first" title="Test button">Button 1</button>
+      <button class="btn btn__grouped" title="Test button">Button 2</button>
+      <button class="btn btn__grouped-last" title="Test button">Button 3</button>
       <br>
       <br>
       <input type="button" value="Input 1" class="btn btn__grouped-first">
@@ -498,9 +498,9 @@ input.btn::-moz-focus-inner {
       <a href="#" class="btn btn__grouped-last btn__super">Anchor 3</a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__super">Button 1</button>
-      <button class="btn btn__grouped btn__super">Button 2</button>
-      <button class="btn btn__grouped-last btn__super">Button 3</button>
+      <button class="btn btn__grouped-first btn__super" title="Test button">Button 1</button>
+      <button class="btn btn__grouped btn__super" title="Test button">Button 2</button>
+      <button class="btn btn__grouped-last btn__super" title="Test button">Button 3</button>
       <br>
       <br>
       <input type="button" value="Input 1" class="btn btn__grouped-first btn__super">
@@ -553,8 +553,8 @@ input.btn::-moz-focus-inner {
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first">Button</button>
-      <button class="btn btn__grouped-last btn__compound-action">
+      <button class="btn btn__grouped-first" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
@@ -565,8 +565,8 @@ input.btn::-moz-focus-inner {
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__secondary">Button</button>
-      <button class="btn btn__grouped-last btn__secondary btn__compound-action">
+      <button class="btn btn__grouped-first btn__secondary" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__secondary btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
@@ -577,8 +577,8 @@ input.btn::-moz-focus-inner {
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__warning">Button</button>
-      <button class="btn btn__grouped-last btn__warning btn__compound-action">
+      <button class="btn btn__grouped-first btn__warning" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__warning btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
@@ -589,14 +589,14 @@ input.btn::-moz-focus-inner {
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__disabled">Button</button>
-      <button class="btn btn__grouped-last btn__disabled btn__compound-action">
+      <button class="btn btn__grouped-first btn__disabled" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__disabled btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
       <br>
-      <button class="btn btn__grouped-first" disabled>Button w/ disabled attr</button>
-      <button class="btn btn__grouped-last btn__compound-action" disabled>
+      <button class="btn btn__grouped-first" disabled title="Test button">Button w/ disabled attr</button>
+      <button class="btn btn__grouped-last btn__compound-action" disabled title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
@@ -607,8 +607,8 @@ input.btn::-moz-focus-inner {
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__super">Button</button>
-      <button class="btn btn__grouped-last btn__super btn__compound-action">
+      <button class="btn btn__grouped-first btn__super" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__super btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
   tags:
@@ -665,22 +665,22 @@ input.btn::-moz-focus-inner {
   - name: Default state
     markup: |
       <a href="#" class="btn btn__link">Anchor Tag</a>
-      <button class="btn btn__link">Button Tag</button>
+      <button class="btn btn__link" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__link hover">Anchor Tag</a>
-      <button class="btn btn__link hover">Button Tag</button>
+      <button class="btn btn__link hover" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__link focus">Anchor Tag</a>
-      <button class="btn btn__link focus">Button Tag</button>
+      <button class="btn btn__link focus" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__link active">Anchor Tag</a>
-      <button class="btn btn__link active">Button Tag</button>
+      <button class="btn btn__link active" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link active">
   tags:
   - cf-buttons
@@ -730,22 +730,22 @@ input.btn::-moz-focus-inner {
   - name: Default state
     markup: |
       <a href="#" class="btn btn__link btn__secondary">Anchor Tag</a>
-      <button class="btn btn__link btn__secondary">Button Tag</button>
+      <button class="btn btn__link btn__secondary" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__secondary">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__link btn__secondary hover">Anchor Tag</a>
-      <button class="btn btn__link btn__secondary hover">Button Tag</button>
+      <button class="btn btn__link btn__secondary hover" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__secondary hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__link btn__secondary focus">Anchor Tag</a>
-      <button class="btn btn__link btn__secondary focus">Button Tag</button>
+      <button class="btn btn__link btn__secondary focus" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__secondary focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__link btn__secondary active">Anchor Tag</a>
-      <button class="btn btn__link btn__secondary active">Button Tag</button>
+      <button class="btn btn__link btn__secondary active" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__secondary active">
   tags:
   - cf-buttons
@@ -781,22 +781,22 @@ input.btn::-moz-focus-inner {
   - name: Default state
     markup: |
       <a href="#" class="btn btn__link btn__warning">Anchor Tag</a>
-      <button class="btn btn__link btn__warning">Button Tag</button>
+      <button class="btn btn__link btn__warning" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__warning">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__link btn__warning hover">Anchor Tag</a>
-      <button class="btn btn__link btn__warning hover">Button Tag</button>
+      <button class="btn btn__link btn__warning hover" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__warning hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__link btn__warning focus">Anchor Tag</a>
-      <button class="btn btn__link btn__warning focus">Button Tag</button>
+      <button class="btn btn__link btn__warning focus" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__warning focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__link btn__warning active">Anchor Tag</a>
-      <button class="btn btn__link btn__warning active">Button Tag</button>
+      <button class="btn btn__link btn__warning active" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__warning active">
   tags:
   - cf-buttons

--- a/package.json
+++ b/package.json
@@ -1,21 +1,29 @@
 {
   "scripts": {
-    "test": "./coverage.sh"
+    "pretest": "forever stopall -s && forever start -s ./node_modules/.bin/http-server",
+    "test": "pa11y localhost:8080/demo -r ci -s WCAG2AA && npm run coverage",
+    "posttest": "forever stopall -s",
+    "coverage": "./coverage.sh"
   },
   "devDependencies": {
     "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git#0.9.1",
     "cf-grunt-config": "~0.3.1",
     "coveralls": "^2.11.2",
+    "forever": "^0.14.1",
     "glob": "~4.3.2",
     "grunt": "~0.4.4",
+    "http-server": "^0.8.0",
     "istanbul": "git://github.com/gotwarlost/istanbul#harmony",
+    "jasmine-node": "~1.14.5",
     "jit-grunt": "~0.9.0",
     "jsx-test": "0.5.0",
     "load-grunt-tasks": "~2.0.0",
     "node.extend": "~1.0.10",
+    "pa11y": "^1.7.0",
+    "pa11y-reporter-ci": "0.0.1",
+    "phantomjs": "^1.9.16",
     "react": "0.13.3",
     "react-tools": "^0.13.3",
-    "time-grunt": "~1.0.0",
-    "jasmine-node": "~1.14.5"
+    "time-grunt": "~1.0.0"
   }
 }

--- a/src/cf-buttons.less
+++ b/src/cf-buttons.less
@@ -90,23 +90,23 @@
   patterns:
   - name: Default state
     markup: |
-      <a href="#" class="btn">Anchor Tag</a>
-      <button class="btn">Button Tag</button>
+      <a href="#" class="btn" title="Test button">Anchor Tag</a>
+      <button class="btn" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn">
   - name: Hovered state
     markup: |
-      <a href="#" class="btn hover">Anchor Tag</a>
-      <button class="btn hover">Button Tag</button>
+      <a href="#" class="btn hover" title="Test button">Anchor Tag</a>
+      <button class="btn hover" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn hover">
   - name: Focused state
     markup: |
-      <a href="#" class="btn focus">Anchor Tag</a>
-      <button class="btn focus">Button Tag</button>
+      <a href="#" class="btn focus" title="Test button">Anchor Tag</a>
+      <button class="btn focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn focus">
   - name: Active state
     markup: |
-      <a href="#" class="btn active">Anchor Tag</a>
-      <button class="btn active">Button Tag</button>
+      <a href="#" class="btn active" title="Test button">Anchor Tag</a>
+      <button class="btn active" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn active">
   tags:
   - cf-buttons
@@ -201,22 +201,22 @@
   - name: Default state
     markup: |
       <a href="#" class="btn btn__secondary">Anchor Tag</a>
-      <button class="btn btn__secondary">Button Tag</button>
+      <button class="btn btn__secondary" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__secondary">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__secondary hover">Anchor Tag</a>
-      <button class="btn btn__secondary hover">Button Tag</button>
+      <button class="btn btn__secondary hover" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__secondary hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__secondary focus">Anchor Tag</a>
-      <button class="btn btn__secondary focus">Button Tag</button>
+      <button class="btn btn__secondary focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__secondary focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__secondary active">Anchor Tag</a>
-      <button class="btn btn__secondary active">Button Tag</button>
+      <button class="btn btn__secondary active" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__secondary active">
   tags:
   - cf-buttons
@@ -256,22 +256,22 @@
 //  - name: Default state
 //    markup: |
 //      <a href="#" class="btn btn__tertiary">Anchor Tag</a>
-//      <button class="btn btn__tertiary">Button Tag</button>
+//      <button class="btn btn__tertiary" title="Test button">Button Tag</button>
 //      <input type="submit" value="Input Tag" class="btn btn__tertiary">
 //  - name: Hovered state
 //    markup: |
 //      <a href="#" class="btn btn__tertiary hover">Anchor Tag</a>
-//      <button class="btn btn__tertiary hover">Button Tag</button>
+//      <button class="btn btn__tertiary hover" title="Test button">Button Tag</button>
 //      <input type="submit" value="Input Tag" class="btn btn__tertiary hover">
 //  - name: Focused state
 //    markup: |
 //      <a href="#" class="btn btn__tertiary focus">Anchor Tag</a>
-//      <button class="btn btn__tertiary focus">Button Tag</button>
+//      <button class="btn btn__tertiary focus" title="Test button">Button Tag</button>
 //      <input type="submit" value="Input Tag" class="btn btn__tertiary focus">
 //  - name: Active state
 //    markup: |
 //      <a href="#" class="btn btn__tertiary active">Anchor Tag</a>
-//      <button class="btn btn__tertiary active">Button Tag</button>
+//      <button class="btn btn__tertiary active" title="Test button">Button Tag</button>
 //      <input type="submit" value="Input Tag" class="btn btn__tertiary active">
 //  tags:
 //  - cf-buttons
@@ -316,22 +316,22 @@
   - name: Default state
     markup: |
       <a href="#" class="btn btn__warning">Anchor Tag</a>
-      <button class="btn btn__warning">Button Tag</button>
+      <button class="btn btn__warning" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__warning">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__warning hover">Anchor Tag</a>
-      <button class="btn btn__warning hover">Button Tag</button>
+      <button class="btn btn__warning hover" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__warning hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__warning focus">Anchor Tag</a>
-      <button class="btn btn__warning focus">Button Tag</button>
+      <button class="btn btn__warning focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__warning focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__warning active">Anchor Tag</a>
-      <button class="btn btn__warning active">Button Tag</button>
+      <button class="btn btn__warning active" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__warning active">
   tags:
   - cf-buttons
@@ -377,15 +377,15 @@
   - name: Default/hovered/active state
     markup: |
       <a href="#" class="btn btn__disabled">Anchor Tag</a>
-      <button class="btn btn__disabled">Button Tag</button>
+      <button class="btn btn__disabled" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__disabled">
-      <button class="btn" disabled>Button Tag w/ disabled attr</button>
+      <button class="btn" disabled title="Test button">Button Tag w/ disabled attr</button>
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__disabled focus">Anchor Tag</a>
-      <button class="btn btn__disabled focus">Button Tag</button>
+      <button class="btn btn__disabled focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__disabled focus">
-      <button class="btn focus" disabled>Button Tag w/ disabled attr</button>
+      <button class="btn focus" disabled title="Test button">Button Tag w/ disabled attr</button>
   tags:
   - cf-buttons
 */
@@ -423,22 +423,22 @@
   - name: Default state
     markup: |
       <a href="#" class="btn btn__super">Anchor Tag</a>
-      <button class="btn btn__super">Button Tag</button>
+      <button class="btn btn__super" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__super">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__super hover">Anchor Tag</a>
-      <button class="btn btn__super hover">Button Tag</button>
+      <button class="btn btn__super hover" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__super hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__super focus">Anchor Tag</a>
-      <button class="btn btn__super focus">Button Tag</button>
+      <button class="btn btn__super focus" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__super focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__super active">Anchor Tag</a>
-      <button class="btn btn__super active">Button Tag</button>
+      <button class="btn btn__super active" title="Test button">Button Tag</button>
       <input type="submit" value="Input Tag" class="btn btn__super active">
   tags:
   - cf-buttons
@@ -480,7 +480,7 @@
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Anchor Tag
       </a>
-      <button class="btn">
+      <button class="btn" title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag
       </button>
@@ -490,7 +490,7 @@
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Anchor Tag
       </a>
-      <button class="btn btn__secondary">
+      <button class="btn btn__secondary" title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag
       </button>
@@ -500,7 +500,7 @@
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Anchor Tag
       </a>
-      <button class="btn btn__warning">
+      <button class="btn btn__warning" title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag
       </button>
@@ -510,11 +510,11 @@
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Anchor Tag
       </a>
-      <button class="btn btn__disabled">
+      <button class="btn btn__disabled" title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag
       </button>
-      <button class="btn" disabled>
+      <button class="btn" disabled title="Test button">
           <span class="btn_icon__left cf-icon cf-icon-left"></span>
           Button Tag w/ disabled attr
       </button>
@@ -524,7 +524,7 @@
           Anchor Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </a>
-      <button class="btn">
+      <button class="btn" title="Test button">
           Button Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
@@ -534,7 +534,7 @@
           Anchor Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </a>
-      <button class="btn btn__secondary">
+      <button class="btn btn__secondary" title="Test button">
           Button Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
@@ -544,7 +544,7 @@
           Anchor Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </a>
-      <button class="btn btn__warning">
+      <button class="btn btn__warning" title="Test button">
           Button Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
@@ -554,11 +554,11 @@
           Anchor Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </a>
-      <button class="btn btn__disabled">
+      <button class="btn btn__disabled" title="Test button">
           Button Tag
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
-      <button class="btn" disabled>
+      <button class="btn" disabled title="Test button">
           Button Tag w/ disabled attr
           <span class="btn_icon__right cf-icon cf-icon-right"></span>
       </button>
@@ -568,7 +568,7 @@
           <span class="u-visually-hidden">Search</span>
           <span class="cf-icon cf-icon-search"></span>
       </a>
-      <button class="btn">
+      <button class="btn" title="Test button">
           <span class="u-visually-hidden">Search</span>
           <span class="cf-icon cf-icon-search"></span>
       </button>
@@ -635,9 +635,9 @@
       <a href="#" class="btn btn__grouped-last">Anchor 3</a>
       <br>
       <br>
-      <button class="btn btn__grouped-first">Button 1</button>
-      <button class="btn btn__grouped">Button 2</button>
-      <button class="btn btn__grouped-last">Button 3</button>
+      <button class="btn btn__grouped-first" title="Test button">Button 1</button>
+      <button class="btn btn__grouped" title="Test button">Button 2</button>
+      <button class="btn btn__grouped-last" title="Test button">Button 3</button>
       <br>
       <br>
       <input type="button" value="Input 1" class="btn btn__grouped-first">
@@ -650,9 +650,9 @@
       <a href="#" class="btn btn__grouped-last btn__super">Anchor 3</a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__super">Button 1</button>
-      <button class="btn btn__grouped btn__super">Button 2</button>
-      <button class="btn btn__grouped-last btn__super">Button 3</button>
+      <button class="btn btn__grouped-first btn__super" title="Test button">Button 1</button>
+      <button class="btn btn__grouped btn__super" title="Test button">Button 2</button>
+      <button class="btn btn__grouped-last btn__super" title="Test button">Button 3</button>
       <br>
       <br>
       <input type="button" value="Input 1" class="btn btn__grouped-first btn__super">
@@ -720,8 +720,8 @@
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first">Button</button>
-      <button class="btn btn__grouped-last btn__compound-action">
+      <button class="btn btn__grouped-first" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
@@ -732,8 +732,8 @@
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__secondary">Button</button>
-      <button class="btn btn__grouped-last btn__secondary btn__compound-action">
+      <button class="btn btn__grouped-first btn__secondary" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__secondary btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
@@ -744,8 +744,8 @@
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__warning">Button</button>
-      <button class="btn btn__grouped-last btn__warning btn__compound-action">
+      <button class="btn btn__grouped-first btn__warning" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__warning btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
@@ -756,14 +756,14 @@
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__disabled">Button</button>
-      <button class="btn btn__grouped-last btn__disabled btn__compound-action">
+      <button class="btn btn__grouped-first btn__disabled" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__disabled btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
       <br>
-      <button class="btn btn__grouped-first" disabled>Button w/ disabled attr</button>
-      <button class="btn btn__grouped-last btn__compound-action" disabled>
+      <button class="btn btn__grouped-first" disabled title="Test button">Button w/ disabled attr</button>
+      <button class="btn btn__grouped-last btn__compound-action" disabled title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
       <br>
@@ -774,8 +774,8 @@
       </a>
       <br>
       <br>
-      <button class="btn btn__grouped-first btn__super">Button</button>
-      <button class="btn btn__grouped-last btn__super btn__compound-action">
+      <button class="btn btn__grouped-first btn__super" title="Test button">Button</button>
+      <button class="btn btn__grouped-last btn__super btn__compound-action" title="Test button">
           <span class="cf-icon cf-icon-down btn__grouped-last"></span>
       </button>
   tags:
@@ -846,22 +846,22 @@
   - name: Default state
     markup: |
       <a href="#" class="btn btn__link">Anchor Tag</a>
-      <button class="btn btn__link">Button Tag</button>
+      <button class="btn btn__link" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__link hover">Anchor Tag</a>
-      <button class="btn btn__link hover">Button Tag</button>
+      <button class="btn btn__link hover" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__link focus">Anchor Tag</a>
-      <button class="btn btn__link focus">Button Tag</button>
+      <button class="btn btn__link focus" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__link active">Anchor Tag</a>
-      <button class="btn btn__link active">Button Tag</button>
+      <button class="btn btn__link active" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link active">
   tags:
   - cf-buttons
@@ -927,22 +927,22 @@
   - name: Default state
     markup: |
       <a href="#" class="btn btn__link btn__secondary">Anchor Tag</a>
-      <button class="btn btn__link btn__secondary">Button Tag</button>
+      <button class="btn btn__link btn__secondary" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__secondary">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__link btn__secondary hover">Anchor Tag</a>
-      <button class="btn btn__link btn__secondary hover">Button Tag</button>
+      <button class="btn btn__link btn__secondary hover" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__secondary hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__link btn__secondary focus">Anchor Tag</a>
-      <button class="btn btn__link btn__secondary focus">Button Tag</button>
+      <button class="btn btn__link btn__secondary focus" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__secondary focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__link btn__secondary active">Anchor Tag</a>
-      <button class="btn btn__link btn__secondary active">Button Tag</button>
+      <button class="btn btn__link btn__secondary active" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__secondary active">
   tags:
   - cf-buttons
@@ -988,22 +988,22 @@
   - name: Default state
     markup: |
       <a href="#" class="btn btn__link btn__warning">Anchor Tag</a>
-      <button class="btn btn__link btn__warning">Button Tag</button>
+      <button class="btn btn__link btn__warning" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__warning">
   - name: Hovered state
     markup: |
       <a href="#" class="btn btn__link btn__warning hover">Anchor Tag</a>
-      <button class="btn btn__link btn__warning hover">Button Tag</button>
+      <button class="btn btn__link btn__warning hover" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__warning hover">
   - name: Focused state
     markup: |
       <a href="#" class="btn btn__link btn__warning focus">Anchor Tag</a>
-      <button class="btn btn__link btn__warning focus">Button Tag</button>
+      <button class="btn btn__link btn__warning focus" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__warning focus">
   - name: Active state
     markup: |
       <a href="#" class="btn btn__link btn__warning active">Anchor Tag</a>
-      <button class="btn btn__link btn__warning active">Button Tag</button>
+      <button class="btn btn__link btn__warning active" title="Test button">Button Tag</button>
       <input type="button" value="Input Tag" class="btn btn__link btn__warning active">
   tags:
   - cf-buttons


### PR DESCRIPTION
Leeeeeet's try this again.
## Additions
- Adds `npm test` script.
- Adds config file for Travis CI.
- Adds Travis CI badge to readme.
## Changes
- I added a bunch of `title` attributes to the demo page because pa11y was complaining about it.
## Testing
- Pull down changes.
- `npm install`
- `npm test`
## Review
- @anselmbradford 
- @himedlooff 
## Notes

The tests are failing because our [grouped buttons](https://github.com/cfpb/cf-buttons/blob/gh-pages/demo/index.html#L311-L313) are anchors without content and pa11y claims that violates [guideline 4.1.2](http://www.w3.org/TR/2008/REC-WCAG20-20081211/#ensure-compat-rsv). Anyone know how we can fix this? Is it truly an issue or can it be ignored?

![pa11y](http://i.imgur.com/NbHAiAn.png)
