### PR TITLE
New @import build process

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "bower_components"
+  "directory": "src/vendor"
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,7 +100,7 @@ module.exports = function(grunt) {
   /**
    * Create custom task aliases for our component build workflow.
    */
-  grunt.registerTask('vendor', ['bower', 'copy:docs_assets', 'concat:main', 'concat:lt-ie8']);
-  grunt.registerTask('default', ['concat:main', 'concat:lt-ie8', 'less', 'autoprefixer', 'copy:docs', 'topdoc']);
+  grunt.registerTask('vendor', ['copy:docs_assets', 'concat:lt-ie8']);
+  grunt.registerTask('default', ['concat:lt-ie8', 'less', 'autoprefixer', 'copy:docs', 'topdoc']);
 
 };

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-buttons",
-  "version": "1.5.1",
+  "version": "1.6.1",
   "description": "Button styles including default, secondary, destructive, disabled, super, and compound buttons, button links, buttons with icons, and button groups for Capital Framework.",
   "keywords": [
     "capital-framework",
@@ -22,8 +22,8 @@
   "license": "https://github.com/cfpb/cf-buttons/blob/gh-pages/TERMS.md",
   "main": "src/cf-buttons.less",
   "dependencies": {
-    "cf-core": "cfpb/cf-core#dev",
-    "cf-icons": "cfpb/cf-icons#dev"
+    "cf-core": "^1.0.0",
+    "cf-icons": "^1.0.0"
   },
   "exportsOverride": {
     "cf-*": {

--- a/bower.json
+++ b/bower.json
@@ -22,8 +22,8 @@
   "license": "https://github.com/cfpb/cf-buttons/blob/gh-pages/TERMS.md",
   "main": "src/cf-buttons.less",
   "dependencies": {
-    "cf-core": "latest",
-    "cf-icons": "latest"
+    "cf-core": "cfpb/cf-core#1.0",
+    "cf-icons": "cfpb/cf-icons#1.0"
   },
   "exportsOverride": {
     "cf-*": {

--- a/bower.json
+++ b/bower.json
@@ -22,8 +22,8 @@
   "license": "https://github.com/cfpb/cf-buttons/blob/gh-pages/TERMS.md",
   "main": "src/cf-buttons.less",
   "dependencies": {
-    "cf-core": "cfpb/cf-core#1.0",
-    "cf-icons": "cfpb/cf-icons#1.0"
+    "cf-core": "cfpb/cf-core#dev",
+    "cf-icons": "cfpb/cf-icons#dev"
   },
   "exportsOverride": {
     "cf-*": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git#0.9.1",
-    "cf-grunt-config": "~0.3.1",
+    "cf-grunt-config": "cfpb/cf-grunt-config#dev",
     "glob": "~4.3.2",
     "grunt": "~0.4.4",
     "jit-grunt": "~0.9.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "coverage": "./coverage.sh"
   },
   "devDependencies": {
-    "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git#0.9.1",
+    "cf-component-demo": "^1.0.0",
     "cf-grunt-config": "^1.0.0",
     "coveralls": "^2.11.2",
     "forever": "^0.14.1",

--- a/src/cf-buttons.less
+++ b/src/cf-buttons.less
@@ -3,6 +3,9 @@
    Button Styling
    ========================================================================== */
 
+@import '../../cf-core/src/cf-core.less';
+@import '../../cf-icons/src/cf-icons.less';
+
 /* topdoc
   name: Theme variables
   family: cf-buttons


### PR DESCRIPTION
This implements the changes discussed in https://github.com/cfpb/capital-framework/issues/151.
## Additions
- `@import` rules to pull in dependencies.
## Removals
- Grunt bower and concat tasks
## Changes
- `bowerrc` points to `src/vendor` (the now defunct Grunt task used to do this).
- Bumped to `1.0.0`.
## Testing
- You can't. :neutral_face: There's a chicken vs. the egg scenario here. This project's dependencies now point to the 1.x.x version of other CF components. But those versions aren't in Bower/npm yet because their PRs are still pending. This is why Travis is failing.
- The `dev` branch was thoroughly tested prior to this PR and more testing will occur afterward. There will likely be some kinks to work out after this merge but that's okay -- semver will shield current projects from any bugs.
## Review
- @Scotchester 
- @anselmbradford 
